### PR TITLE
[BE] Pin 상세보기 페이지 수정

### DIFF
--- a/everyplace/pin/urls.py
+++ b/everyplace/pin/urls.py
@@ -7,7 +7,8 @@ urlpatterns = [
     # 핀 생성
     path('', views.PinView.as_view(), name='pin-create'),
     # 핀 상세정보 조회
-    path('<int:pk>/', views.PinView.as_view(), name='pin-detail'),
+    path('<str:title>/<str:lat_lng>/',
+         views.PinView.as_view(), name='pin-detail'),
     # 핀 컨텐츠 수정, 삭제
     path('content/<int:pk>/',
          views.PinView.as_view(), name='pin-content'),

--- a/everyplace/pin/views.py
+++ b/everyplace/pin/views.py
@@ -6,9 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.db.models import Q
 from .models import Pin, PinContent
 from .serializers import PinSerializer, PinContentSerializer
-from django.contrib.auth import get_user_model
-
-User = get_user_model()
+from rest_framework.pagination import PageNumberPagination
 
 
 # Create your views here.
@@ -19,17 +17,30 @@ class PinView(APIView):
     def get(self, request, title, lat_lng):
         pin = get_object_or_404(
             Pin, title=title, lat_lng=lat_lng, is_deleted=False)
+
+        # pin에 포함된 pin content 갯수 세기
+        pin_content_count = PinContent.objects.filter(
+            pin_id=pin, is_deleted=False).count()
+
+        # 페이지네이션 적용
+        paginator = PageNumberPagination()
+        paginator.page_size = 3
         # pin content 중 내용이 없는 객체는 보여주지 않음. 최신순으로 정렬
         pin_contents = PinContent.objects.filter(
             pin_id=pin, is_deleted=False).exclude(Q(text__isnull=True, photo='')).order_by('-created_at')
 
-        pin_serializer = PinSerializer(pin)
-        pin_contents_serializer = PinContentSerializer(pin_contents, many=True)
+        # 쿼리셋 페이지네이트
+        pin_contents_page = paginator.paginate_queryset(pin_contents, request)
 
-        return Response({
+        pin_serializer = PinSerializer(pin)
+        pin_contents_serializer = PinContentSerializer(
+            pin_contents_page, many=True)
+
+        return paginator.get_paginated_response({
             'pin': pin_serializer.data,
-            'pin_contents': pin_contents_serializer.data
-        }, status=status.HTTP_200_OK)
+            'pin_contents': pin_contents_serializer.data,
+            'pin_content_count': pin_content_count
+        })
 
     # ## pin 생성
     def post(self, request):

--- a/everyplace/pin/views.py
+++ b/everyplace/pin/views.py
@@ -16,8 +16,9 @@ class PinView(APIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     # ## pin 상세정보 조회
-    def get(self, request, pk):
-        pin = get_object_or_404(Pin, pk=pk, is_deleted=False)
+    def get(self, request, title, lat_lng):
+        pin = get_object_or_404(
+            Pin, title=title, lat_lng=lat_lng, is_deleted=False)
         # pin content 중 내용이 없는 객체는 보여주지 않음. 최신순으로 정렬
         pin_contents = PinContent.objects.filter(
             pin_id=pin, is_deleted=False).exclude(Q(text__isnull=True, photo='')).order_by('-created_at')


### PR DESCRIPTION
## 수정 사항

- 프론트에서 보내줄 수 있는 데이터에 맞춰 pin 상세보기 페이지 url을 "pin/<str:title>/<str:lat_lng>/ " 형식으로 수정하였습니다.
- pin content를 한번에 3개씩 볼 수 있도록 pagination을 적용했습니다.
- pin에 연결된 pin content 개수를 표시하도록 변경하였습니다.