### PR TITLE
[BE] Board 좋아요 등록, 해제, 조회 기능

### DIFF
--- a/everyplace/board/serializers.py
+++ b/everyplace/board/serializers.py
@@ -24,11 +24,11 @@ class BoardSerializer(serializers.ModelSerializer):
 class BoardCommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = BoardComment
-        fields = ('board_id', 'user_id', 'content', 'created_at', 'is_deleted')
+        fields = ('id', 'board_id', 'user_id', 'content', 'created_at', 'is_deleted')
 
 
 # BoardLike
 class BoardLikeSerializer(serializers.ModelSerializer):
     class Meta:
         model = BoardLike
-        fields = ('board_id', 'user_id', 'created_at', 'is_deleted')
+        fields = ('id', 'board_id', 'user_id', 'created_at', 'is_deleted')

--- a/everyplace/board/serializers.py
+++ b/everyplace/board/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
-from .models import Board, BoardTag, BoardLike, BoardComment
+from .models import Board, BoardTag, BoardComment, BoardLike
 
 User = get_user_model()
 
@@ -25,3 +25,10 @@ class BoardCommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = BoardComment
         fields = ('board_id', 'user_id', 'content', 'created_at', 'is_deleted')
+
+
+# BoardLike
+class BoardLikeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BoardLike
+        fields = ('board_id', 'user_id', 'created_at', 'is_deleted')

--- a/everyplace/board/urls.py
+++ b/everyplace/board/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
 
     # BoardLike
     path('<int:pk>/like/', views.BoardLikeView.as_view(), name='boardlike_create'),
+    path('like/<int:pk>/', views.BoardLikeView.as_view(), name='boardlike_delete'),
 ]

--- a/everyplace/board/urls.py
+++ b/everyplace/board/urls.py
@@ -11,4 +11,7 @@ urlpatterns = [
     # BoardComment
     path('<int:pk>/comment/', views.BoardCommentView.as_view(), name='boardcomment_create'),
     path('comment/<int:pk>/', views.BoardCommentView.as_view(), name='boardcomment_delete'),
+
+    # BoardLike
+    path('<int:pk>/like/', views.BoardLikeView.as_view(), name='boardlike_create'),
 ]

--- a/everyplace/board/urls.py
+++ b/everyplace/board/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     # BoardLike
     path('<int:pk>/like/', views.BoardLikeView.as_view(), name='boardlike_create'),
     path('like/<int:pk>/', views.BoardLikeView.as_view(), name='boardlike_delete'),
+    path('like/', views.BoardLikeView.as_view(), name='boardlike_list'),
 ]

--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -43,6 +43,9 @@ class BoardView(APIView):
             # 해당 보드와 연결된 모든 댓글(Comment) 객체들 반환
             # 최신순으로 정렬
             comments = BoardComment.objects.filter(board_id=pk, is_deleted=False).order_by('-created_at')
+
+            # 해당 보드에 대한 좋아요 개수 출력
+            likes_count = BoardLike.objects.filter(board_id=pk, is_deleted=False).count()
             
             pin_serializer = SimplePinSerializer(pins, many=True)
             comment_serializer = BoardCommentSerializer(comments, many=True)
@@ -50,6 +53,7 @@ class BoardView(APIView):
 
             data = {
                 'board': board_serializer.data,
+                'likes_count': likes_count,
                 'pins': pin_serializer.data,
                 'comments': comment_serializer.data
             }

--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -233,7 +233,7 @@ class BoardCommentView(APIView):
 
 ## BoardLike View
 class BoardLikeView(APIView):
-    ## 좋아요 등록
+    ## 보드 좋아요 등록
     def post(self, request, pk):
         board = get_object_or_404(Board, pk=pk)
         user = request.user
@@ -250,7 +250,7 @@ class BoardLikeView(APIView):
         
         return Response(serializer.error, status=400)
     
-    ## 좋아요 해제
+    ## 보드 좋아요 해제
     def delete(self, request, pk):
         user = request.user
         board_like = get_object_or_404(BoardLike, pk=pk,  user_id=user.id)
@@ -263,3 +263,18 @@ class BoardLikeView(APIView):
         board_like.save()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+    
+    ## 보드 좋아요 목록 조회
+    def get(self, request):
+        user = request.user
+
+        # 유저가 좋아요한 보드 목록을 필터링하여 BoardLike 모델 객체들 추출
+        # 최신순 정렬된 상태로 추출
+        board_likes = BoardLike.objects.filter(user_id=user.id, is_deleted=False).order_by('-created_at')
+
+        # 추출한 객체들의 id값 리스트로 저장
+        boards = [board_like.board_id for board_like in board_likes]
+
+        serializer = BoardSerializer(instance=boards, many=True)
+
+        return Response(serializer.data)

--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -236,3 +236,17 @@ class BoardLikeView(APIView):
             return Response(serializer.data, status=201)
         
         return Response(serializer.error, status=400)
+    
+    ## 좋아요 해제
+    def delete(self, request, pk):
+        user = request.user
+        board_like = get_object_or_404(BoardLike, pk=pk,  user_id=user.id)
+
+        # 이미 해제된 경우 -> 에러 응답 반환
+        if board_like.is_deleted:
+            return Response({'error': '이미 이 보드에 좋아요가 해제되었습니다.'})
+        
+        board_like.is_deleted = True
+        board_like.save()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -20,6 +20,10 @@ class BoardView(APIView):
         
         except Board.DoesNotExist:
             return None
+        
+    ## 로그인 된 유저의 좋아요 여부 판단 메소드
+    def is_board_liked_by_user(self,user_id ,board_id):
+        return BoardLike.objects.filter(user_id=user_id, board_id=board_id, is_deleted=False).exists()
 
     def get(self, request, pk=None):
         ## 보드 전체 목록 조희
@@ -44,6 +48,10 @@ class BoardView(APIView):
             # 최신순으로 정렬
             comments = BoardComment.objects.filter(board_id=pk, is_deleted=False).order_by('-created_at')
 
+            # 해당 보드에 대한 로그인된 유저의 좋아요 여부 출력
+            # is_board_liked_by_user 메소드의 반환 값으로 확인
+            user_liked = self.is_board_liked_by_user(request.user.id, pk)
+
             # 해당 보드에 대한 좋아요 개수 출력
             likes_count = BoardLike.objects.filter(board_id=pk, is_deleted=False).count()
             
@@ -53,6 +61,7 @@ class BoardView(APIView):
 
             data = {
                 'board': board_serializer.data,
+                'user_liked': user_liked,
                 'likes_count': likes_count,
                 'pins': pin_serializer.data,
                 'comments': comment_serializer.data


### PR DESCRIPTION
board앱의 좋아요 기능을 구현하였습니다.

## 구현내용
- 유저의 보드 좋아요 목록 조회 기능
- 좋아요 등록 기능
- 좋아요 해제 기능
- 보드 상세보기 시 보드의 좋아요 개수 출력
- 보드 상세보기 시 유저의 좋아요 여부 출력 

## 참고사항
- 보드 좋아요 목록은 최신순으로 정렬되도록 구현하였습니다.
- 보드 상세보기 시 좋아요 개수가 표기됩니다.
- 보드 상세보기 시 로그인 된 유저의 보드 좋아요 여부가 표기됩니다.
<img width="400" alt="image" src="https://github.com/inslog94/project/assets/43246395/92223735-a9b6-477c-b2ba-7321c67123e8">

> - 로그인된 유저가 보드 '좋아요' 등록된 상태: "user_liked": true
> - 로그인된 유저가 보드 '좋아요' 해제된 상태: "user_liked": false
> - 해당 보드의 좋아요 개수: "likes_count": 2

## 수정사항
- 프론트단과 값을 편리하게 주고 받기 위하여 board앱의 serializer에 id필드를 일괄 추가하였습니다.

close #22 