### PR TITLE
[BE] 팔로우 등록, 해제, 목록 조회 기능 구현

### DIFF
--- a/everyplace/user/serializers.py
+++ b/everyplace/user/serializers.py
@@ -19,3 +19,14 @@ class FollowingSerializer(serializers.ModelSerializer):
     # 유저 정보 추가
     def get_followed_user_info(self, obj):
         return UserSerializer(obj.followed_user).data
+
+
+class FollowerSerializer(serializers.ModelSerializer):
+    following_user_info = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = Follow
+        fields = ('id', 'following_user', 'followed_user', 'following_user_info')
+    # 유저 정보 추가
+    def get_following_user_info(self, obj):
+        return UserSerializer(obj.following_user).data

--- a/everyplace/user/serializers.py
+++ b/everyplace/user/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
+from .models import Follow
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -7,3 +8,14 @@ class UserSerializer(serializers.ModelSerializer):
         model = get_user_model()
         fields = ('email', 'password', 'nickname', 'profile_img')
         extra_kwargs = {'password': {'write_only': True}}
+
+
+class FollowingSerializer(serializers.ModelSerializer):
+    followed_user_info = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = Follow
+        fields = ('id', 'following_user', 'followed_user', 'followed_user_info')
+    # 유저 정보 추가
+    def get_followed_user_info(self, obj):
+        return UserSerializer(obj.followed_user).data

--- a/everyplace/user/urls.py
+++ b/everyplace/user/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     path('<int:pk>/', views.UserInfoView.as_view(), name='user_info'),
     # User Follow
     path('follow/', views.UserFollow.as_view(), name='follow'),
+    path('follow/<int:pk>/', views.UserFollow.as_view(), name='unfollow'),
 ]

--- a/everyplace/user/urls.py
+++ b/everyplace/user/urls.py
@@ -21,4 +21,6 @@ urlpatterns = [
     # User Profile
     path('me/', views.UserInfoView.as_view(), name='my_info'),
     path('<int:pk>/', views.UserInfoView.as_view(), name='user_info'),
+    # User Follow
+    path('follow/', views.UserFollow.as_view(), name='follow'),
 ]

--- a/everyplace/user/urls.py
+++ b/everyplace/user/urls.py
@@ -27,4 +27,7 @@ urlpatterns = [
     # User Following List
     path('following/', views.UserFollowing.as_view(), name='my_following_list'),
     path('<int:pk>/following/', views.UserFollowing.as_view(), name='user_following_list'),
+    # User Follower List
+    path('follower/', views.UserFollower.as_view(), name='my_follower_list'),
+    path('<int:pk>/follower/', views.UserFollower.as_view(), name='user_follower_list'),
 ]

--- a/everyplace/user/urls.py
+++ b/everyplace/user/urls.py
@@ -24,4 +24,7 @@ urlpatterns = [
     # User Follow
     path('follow/', views.UserFollow.as_view(), name='follow'),
     path('follow/<int:pk>/', views.UserFollow.as_view(), name='unfollow'),
+    # User Following List
+    path('following/', views.UserFollowing.as_view(), name='my_following_list'),
+    path('<int:pk>/following/', views.UserFollowing.as_view(), name='user_following_list'),
 ]

--- a/everyplace/user/views.py
+++ b/everyplace/user/views.py
@@ -15,7 +15,7 @@ from allauth.socialaccount.providers.google import views as google_view
 from allauth.socialaccount.providers.kakao import views as kakao_view
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from allauth.socialaccount.models import SocialAccount
-from .models import User
+from .models import User, Follow
 from .serializers import UserSerializer
 from board.models import Board
 from board.serializers import BoardSerializer
@@ -321,3 +321,19 @@ class UserInfoView(APIView):
             return JsonResponse({'Profile Update': serializer.data}, status=status.HTTP_200_OK)
         
         return JsonResponse({'err_msg': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+# 유저 팔로우
+class UserFollow(APIView):
+    
+    def post(self, request):
+        # 팔로우할 user 가져오기
+        user_id = request.data.get('user_id')
+        followed_user = User.objects.get(id=user_id)
+        
+        # 기존에 팔로우 내역이 있는지 조회(중복 생성 방지) - is_deleted가 True인 경우엔 새로 생성
+        follow, created = Follow.objects.get_or_create(following_user=request.user, followed_user=followed_user, is_deleted=False)
+        
+        if created:
+            return JsonResponse({'Follow': 'success'}, status=status.HTTP_201_CREATED)
+        
+        return JsonResponse({'Follow': '이미 팔로우한 유저입니다.'}, status=status.HTTP_400_BAD_REQUEST)

--- a/everyplace/user/views.py
+++ b/everyplace/user/views.py
@@ -16,7 +16,7 @@ from allauth.socialaccount.providers.kakao import views as kakao_view
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from allauth.socialaccount.models import SocialAccount
 from .models import User, Follow
-from .serializers import UserSerializer
+from .serializers import UserSerializer, FollowingSerializer
 from board.models import Board
 from board.serializers import BoardSerializer
 
@@ -348,3 +348,18 @@ class UserFollow(APIView):
         follow.save()
         
         return JsonResponse({'UnFollow': 'success'}, status=status.HTTP_204_NO_CONTENT)
+
+
+# 팔로잉 목록 조회
+class UserFollowing(APIView):
+    
+    def get(self, request, pk=None):
+        if not pk:
+            user_id = request.user.id
+        else:
+            user_id = pk
+        
+        # 특정 유저가 팔로우하는 리스트를 가져와 유저 정보와 함께 응답
+        following = Follow.objects.filter(following_user_id=user_id, is_deleted=False)
+        serializer = FollowingSerializer(following, many=True)
+        return JsonResponse({'Following List': serializer.data}, status=status.HTTP_200_OK)

--- a/everyplace/user/views.py
+++ b/everyplace/user/views.py
@@ -322,7 +322,7 @@ class UserInfoView(APIView):
         
         return JsonResponse({'err_msg': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
 
-# 유저 팔로우
+# 유저 팔로우, 팔로우 해제
 class UserFollow(APIView):
     
     def post(self, request):
@@ -337,3 +337,14 @@ class UserFollow(APIView):
             return JsonResponse({'Follow': 'success'}, status=status.HTTP_201_CREATED)
         
         return JsonResponse({'Follow': '이미 팔로우한 유저입니다.'}, status=status.HTTP_400_BAD_REQUEST)
+    
+    def delete(self,request, pk):
+        # 팔로우 해제할 user 가져오기
+        followed_user = User.objects.get(id=pk)
+        
+        # 해당 유저 팔로우 해제 - is_deleted 필드 True로 변경
+        follow = Follow.objects.get(following_user=request.user, followed_user=followed_user, is_deleted=False)
+        follow.is_deleted = True
+        follow.save()
+        
+        return JsonResponse({'UnFollow': 'success'}, status=status.HTTP_204_NO_CONTENT)

--- a/everyplace/user/views.py
+++ b/everyplace/user/views.py
@@ -16,7 +16,7 @@ from allauth.socialaccount.providers.kakao import views as kakao_view
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from allauth.socialaccount.models import SocialAccount
 from .models import User, Follow
-from .serializers import UserSerializer, FollowingSerializer
+from .serializers import UserSerializer, FollowingSerializer, FollowerSerializer
 from board.models import Board
 from board.serializers import BoardSerializer
 
@@ -349,7 +349,6 @@ class UserFollow(APIView):
         
         return JsonResponse({'UnFollow': 'success'}, status=status.HTTP_204_NO_CONTENT)
 
-
 # 팔로잉 목록 조회
 class UserFollowing(APIView):
     
@@ -363,3 +362,17 @@ class UserFollowing(APIView):
         following = Follow.objects.filter(following_user_id=user_id, is_deleted=False)
         serializer = FollowingSerializer(following, many=True)
         return JsonResponse({'Following List': serializer.data}, status=status.HTTP_200_OK)
+
+# 팔로워 목록 조회
+class UserFollower(APIView):
+    
+    def get(self, request, pk=None):
+        if not pk:
+            user= request.user
+        else:
+            user = User.objects.get(id=pk)
+        
+        # 특정 유저를 팔로우하는 리스트를 가져와 유저 정보와 함께 응답
+        follower = Follow.objects.filter(followed_user_id=user.id, is_deleted=False)
+        serializer = FollowerSerializer(follower, many=True)
+        return JsonResponse({'Follower List': serializer.data}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## 구현사항

* 유저 팔로우 기능
* 유저 팔로우 해제 기능
* 특정 유저가 팔로우 하는 목록 조회 기능
* 특정 유저를 팔로우 하는 목록 조회 기능

## 참고사항
* 팔로우 시 팔로우 할 user_id를 body에 담아 POST Method로 전달해주셔야 합니다.
* 팔로우 해제 시 언팔로우 할 user_id를 URL에 담아 DELETE Method로 전달해주셔야 합니다.
* 팔로우 목록 조회 시 조회된 유저들의 프로필 정보가 함께 전달되도록 구현하였습니다.

![following](https://github.com/inslog94/project/assets/131739338/d7a957d5-9ded-4cb6-9938-5f78e80cd2f6) | ![follower](https://github.com/inslog94/project/assets/131739338/014dff8d-f503-4346-b696-dbbc66756c73)
:---:|:---:|
user 뒤에 pk 값을 넣어주면 특정 유저 조회가 가능합니다.|pk 값이 없는 경우엔 본인 정보가 조회됩니다.|

close #21 