### PR TITLE
[BE] board 수정 시 핀 삭제만 가능하도록 코드 수정 (핀 추가 코드 삭제)

### DIFF
--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -130,16 +130,6 @@ class BoardView(APIView):
             new_pins = request.data.get('pins', []) # 새롭게 전달된 핀 목록
             existing_pins = board.pin_set.all() # 기존에 존재하는 핀
 
-            for pin_id in new_pins:
-                try:
-                    pin = Pin.objects.get(id=pin_id)
-
-                    if pin not in existing_pins:
-                        board.pin_set.add(pin) # 기존에 없던 핀을 보드에 추가
-
-                except Pin.DoesNotExist:
-                    pass
-
             # 기존에 있는 핀 중에서 전달된 핀 리스트에 없는 것은 삭제
             for pin in existing_pins:
                 if pin.id not in new_pins:


### PR DESCRIPTION
보드 수정 기능을 담당하는 코드를 일부 수정하였습니다.

#### 수정 내용
- 보드 수정 시 핀 추가, 삭제가 가능하였지만 핀 삭제만 가능하도록 코드 수정
- 즉, 핀을 추가하는 부분의 코드 삭제
(핀 추가는 핀 생성 url로 연결 예정)

