### PR TITLE
[BE] 프론트 연결 시 문제되는 Pin 관련 부분의 url, view, serializer 수정

### DIFF
--- a/everyplace/pin/paginations.py
+++ b/everyplace/pin/paginations.py
@@ -1,0 +1,16 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class CustomPagination(PageNumberPagination):
+    def get_paginated_response(self, data):
+        return Response({
+            'links': {
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link(),
+                'total_pages': self.page.paginator.num_pages,
+                'current_page': self.page.number,
+                'count': self.page.paginator.count,
+            },
+            'results': data
+        })

--- a/everyplace/pin/serializers.py
+++ b/everyplace/pin/serializers.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 from .models import Pin, PinContent
 from django.contrib.auth import get_user_model
-from user.serializers import UserSerializer
 
 User = get_user_model()
 
@@ -16,14 +15,19 @@ class PinSerializer(serializers.ModelSerializer):
 
 class PinContentSerializer(serializers.ModelSerializer):
     email = serializers.SerializerMethodField()
+    pin_title = serializers.SerializerMethodField()
 
     class Meta:
         model = PinContent
-        fields = ['id', 'email', 'user_id', 'text', 'photo']
+        fields = ['id', 'email', 'user_id', 'text', 'photo', 'pin_title']
 
     # 유저 email 정보 추가
     def get_email(self, obj):
-        return UserSerializer(obj.user_id).data['email']
+        return User.objects.get(id=obj.user_id_id).email
+
+    # 해당 핀의 Title 추가
+    def get_pin_title(self, obj):
+        return Pin.objects.get(id=obj.pin_id_id).title
 
 
 # 보드 상세보기 시 표기 될 내용을 담은 serializer

--- a/everyplace/pin/serializers.py
+++ b/everyplace/pin/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import Pin, PinContent
 from django.contrib.auth import get_user_model
+from user.serializers import UserSerializer
 
 User = get_user_model()
 
@@ -10,14 +11,19 @@ class PinSerializer(serializers.ModelSerializer):
     class Meta:
         model = Pin
         fields = ['category', 'board_id', 'place_id', 'title',
-                  'thumbnail_img', 'new_address', 'old_address', 'lat_lng']
+                  'thumbnail_img', 'new_address', 'old_address', 'lat_lng', 'updated_at']
 
 
 class PinContentSerializer(serializers.ModelSerializer):
+    email = serializers.SerializerMethodField()
 
     class Meta:
         model = PinContent
-        fields = ['user_id', 'text', 'photo']
+        fields = ['id', 'email', 'user_id', 'text', 'photo']
+
+    # 유저 email 정보 추가
+    def get_email(self, obj):
+        return UserSerializer(obj.user_id).data['email']
 
 
 # 보드 상세보기 시 표기 될 내용을 담은 serializer

--- a/everyplace/pin/urls.py
+++ b/everyplace/pin/urls.py
@@ -6,10 +6,10 @@ app_name = 'pin'
 urlpatterns = [
     # 핀 생성
     path('', views.PinView.as_view(), name='pin-create'),
-    # 핀 상세정보 조회
-    path('<str:title>/<str:lat_lng>/',
-         views.PinView.as_view(), name='pin-detail'),
     # 핀 컨텐츠 수정, 삭제
     path('content/<int:pk>/',
-         views.PinView.as_view(), name='pin-content'),
+         views.PinContentView.as_view(), name='pin-content'),
+    # 핀 상세정보 조회
+    path('<str:place_id>/',
+         views.PinView.as_view(), name='pin-detail'),
 ]

--- a/everyplace/pin/views.py
+++ b/everyplace/pin/views.py
@@ -64,9 +64,9 @@ class PinView(APIView):
 
     # ## pin 상세정보 조회
 
-    def get(self, request, title, lat_lng):
+    def get(self, request, place_id):
         pin = get_object_or_404(
-            Pin, title=title, lat_lng=lat_lng, is_deleted=False)
+            Pin, place_id=place_id, is_deleted=False)
 
         # pin에 포함된 pin content 갯수 세기
         pin_content_count = PinContent.objects.filter(
@@ -162,6 +162,8 @@ class PinView(APIView):
             'pin_content_errors': {}
         }, status=status.HTTP_400_BAD_REQUEST)
 
+
+class PinContentView(APIView):
     # ## pin content 수정
     def put(self, request, pk):
         pin_content = get_object_or_404(PinContent, pk=pk)

--- a/everyplace/pin/views.py
+++ b/everyplace/pin/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.db.models import Q
 from .models import Pin, PinContent
 from .serializers import PinSerializer, PinContentSerializer
-from rest_framework.pagination import PageNumberPagination
+from .paginations import CustomPagination
 import json
 import requests
 from bs4 import BeautifulSoup
@@ -73,7 +73,7 @@ class PinView(APIView):
             pin_id=pin, is_deleted=False).count()
 
         # 페이지네이션 적용
-        paginator = PageNumberPagination()
+        paginator = CustomPagination()
         paginator.page_size = 3
         # pin content 중 내용이 없는 객체는 보여주지 않음. 최신순으로 정렬
         pin_contents = PinContent.objects.filter(


### PR DESCRIPTION
## 수정 사항

- pin 시리얼라이저를 수정했습니다.
  - 프론트 응답에 필요한 PinSerializer의 updated_at 필드를 추가했습니다.
  - 프론트 응답에 필요한 PinContentSerializer의 id, email, pin_title 필드를 추가했습니다.
- url에 필요한 값이 달라 생기는 에러를 방지하기 위해 핀 콘텐츠와 관련된 수정, 삭제 기능을 PinView에서 분리하여 새로운 클래스로 만들었습니다.
- 프론트에서 숫자 버튼을 통해 핀 콘텐츠 페이지를 이동할 수 있도록 페이지네이션 부분을 수정했습니다.