### PR TITLE
[BE] Board 프론트와 유연하게 연결 위한 전체적인 코드 수정

### DIFF
--- a/everyplace/board/serializers.py
+++ b/everyplace/board/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from .models import Board, BoardTag, BoardComment, BoardLike
+from user.serializers import UserSerializer
 
 User = get_user_model()
 
@@ -12,19 +13,35 @@ class BoardTagSerializer(serializers.ModelSerializer):
 
 
 class BoardSerializer(serializers.ModelSerializer):
-    # user_id = serializers.IntegerField(read_only=True)
-    # tags = BoardTagSerializer(many=True, read_only=True)
+
+    tags = serializers.SerializerMethodField()
+    user = serializers.SerializerMethodField()
 
     class Meta:
         model = Board
-        fields = ('id', 'user_id', 'tags', 'title', 'created_at', 'updated_at', 'is_deleted', 'is_public')
+        fields = ('id', 'user_id', 'user', 'tags', 'title', 'created_at', 'updated_at', 'is_deleted', 'is_public')
 
+    # 유저 정보 추가
+    def get_user(self, obj):
+        return UserSerializer(obj.user_id).data
+    
+    # 태그들의 content 값 리스트 형태로 추가
+    def get_tags(self, obj):
+        tags = obj.tags.all()
+        tag_contents = [tag.content for tag in tags]  
+        return tag_contents
 
 # BoardComment
 class BoardCommentSerializer(serializers.ModelSerializer):
+    user = serializers.SerializerMethodField()
+
     class Meta:
         model = BoardComment
-        fields = ('id', 'board_id', 'user_id', 'content', 'created_at', 'is_deleted')
+        fields = ('id', 'board_id', 'user_id', 'user', 'content', 'created_at', 'is_deleted')
+
+    # 유저 정보 추가
+    def get_user(self, obj):
+        return UserSerializer(obj.user_id).data
 
 
 # BoardLike

--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -5,6 +5,7 @@ from .models import Board, BoardTag, BoardComment, BoardLike
 from pin.models import Pin
 from .serializers import BoardSerializer, BoardTagSerializer, BoardCommentSerializer, BoardLikeSerializer
 from pin.serializers import SimplePinSerializer
+from user.serializers import BoardPinSerializer
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.decorators import authentication_classes, permission_classes
@@ -30,7 +31,7 @@ class BoardView(APIView):
         ## 보드 전체 목록 조희
         if not pk:
             boards = Board.objects.filter(is_deleted=False)
-            serializer = BoardSerializer(boards, many=True)
+            serializer = BoardPinSerializer(boards, many=True)
 
             return Response(serializer.data)
         

--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -25,7 +25,12 @@ class BoardView(APIView):
         
     ## 로그인 된 유저의 좋아요 여부 판단 메소드
     def is_board_liked_by_user(self,user_id ,board_id):
-        return BoardLike.objects.filter(user_id=user_id, board_id=board_id, is_deleted=False).exists()
+        board_like = BoardLike.objects.filter(user_id=user_id, board_id=board_id, is_deleted=False)
+
+        if board_like.exists():
+            return True, board_like.values('id')[0]['id']
+    
+        return False, None
 
     def get(self, request, pk=None):
         ## 보드 전체 목록 조희
@@ -231,8 +236,8 @@ class BoardLikeView(APIView):
         user = request.user
 
         # 이미 좋아요한 경우 -> 에러 응답 반환
-        if BoardLike.objects.filter(board_id=board.id, user_id=user.id).exists():
-            return Response({'error': '이미 이 보드에 좋아요를 눌렀습니다.'}, status=400)
+        # if BoardLike.objects.filter(board_id=board.id, user_id=user.id).exists():
+        #     return Response({'error': '이미 이 보드에 좋아요를 눌렀습니다.'}, status=400)
         
         serializer = BoardLikeSerializer(data={'board_id': board.id, 'user_id': user.id})
 


### PR DESCRIPTION
### 수정사항
- board 특정 유저의 좋아요 여부 판단 메소드 유저의 pk 값 추가
- 좋아요 등록 -> 해제 -> 등록 시 새로운 컬럼으로 DB에 추가되도록 해당 내용 코드 삭제
- BoardSerializer, BoardCommentSerializer에 유저 객체 추가
   - 프론트 단에서 유저 정보 식별 더욱 편리하도록 하기 위함
- board 전체 목록 조회 시 핀 썸네일 표기되도록 BoardPinSerializer 사용
   - 프론트 단에서 보드 정보와 내부 핀 목록을 간략히 볼 수 있도록하기 위함