### PR TITLE
[FE] [BE] 보드 전체 목록 비공개보드 처리 및 UX, UI 개선

### DIFF
--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -39,7 +39,17 @@ class BoardView(APIView):
 
         ## 보드 전체 목록 조희
         if not pk:
-            boards = Board.objects.filter(is_deleted=False)
+            # 현재 로그인한 사용자 정보
+            user = request.user
+
+            if user.is_authenticated:
+                # 사용자와 보드 작성자가 같은 경우 공개/비공개에 상관 없이 사용자의 모든 보드 출력
+                # 사용자와 보드 작성자가 다른 경우 공개 보드만 보드만 출력
+                boards = Board.objects.filter(Q(user_id=user) | Q(is_public=True), is_deleted=False)
+            else:
+                # 로그인하지 않은 사용자는 공개 보드만 출력
+                boards = Board.objects.filter(is_public=True, is_deleted=False)
+
             serializer = BoardPinSerializer(boards, many=True)
 
             return Response(serializer.data)

--- a/frontend/assets/html/board_detail.html
+++ b/frontend/assets/html/board_detail.html
@@ -322,6 +322,16 @@
         width: 800px;
         height: 400px;
       }
+
+      .no-pins-message {
+        display: flex;
+        justify-content: center;
+      }
+
+      .pins-hovered {
+        cursor: pointer;
+        background-color: beige !important;
+      }
     </style>
   </head>
 

--- a/frontend/assets/html/board_detail.html
+++ b/frontend/assets/html/board_detail.html
@@ -332,6 +332,13 @@
         cursor: pointer;
         background-color: beige !important;
       }
+
+      .no-tags-message {
+        background-color: #f7f7f7;
+        padding: 12px;
+        display: flex;
+        justify-content: center;
+      }
     </style>
   </head>
 
@@ -461,16 +468,12 @@
                           >
                         </li>
                         <li>
-                          <a href="#">
                             <i class="fa fa-calendar-o"></i>
-                            <span class="board-createdAt">12 Aug 2021</span></a
-                          >
+                            <span class="board-createdAt">12 Aug 2021</span>
                         </li>
                         <li>
-                          <a href="#">
                             <i class="fa fa-star"></i>
-                            <span class="board-likedCnt">좋아요개수</span></a
-                          >
+                            <span class="board-likedCnt">좋아요개수</span>
                         </li>
                       </ul>
                     </div>

--- a/frontend/assets/html/board_detail.html
+++ b/frontend/assets/html/board_detail.html
@@ -463,7 +463,7 @@
                       <ul>
                         <li>
                           <i class="fa fa-user-circle-o"></i>
-                          <a href="#">
+                          <a href="#" class="user-profile-link">
                             <span class="board-userId">작성자ID</span></a
                           >
                         </li>

--- a/frontend/assets/html/board_detail.html
+++ b/frontend/assets/html/board_detail.html
@@ -406,7 +406,7 @@
           <div class="row">
             <div class="main">
               <div class="blog-entry mb-10">
-                <div class="entry-image clearfix">
+                <div class="entry-image clearfix map">
                   <!--지도 넣어야함-->
                   <div style="display: flex; width: 1600px">
                     <div class="map_wrap" style="width: 70%; height: 700px">

--- a/frontend/assets/js/maps/board.js
+++ b/frontend/assets/js/maps/board.js
@@ -92,6 +92,7 @@ export function displayMainBoards(boards) {
 
   // 함수로 동적 생성
   function createBlogEntry(board) {
+
     const masonryItem = document.createElement('div');
     masonryItem.classList.add('masonry-item');
 
@@ -156,6 +157,17 @@ export function displayMainBoards(boards) {
     const titleLink = document.createElement('a');
     titleLink.setAttribute('href', '#');
     titleLink.textContent = board.title;
+
+    // 본인의 비공개 보드 표기
+    const entryLock = document.createElement('span');
+    if (board.is_public === false) {
+      const lock = document.createElement('i');
+      lock.className = 'fa fa-solid fa-lock mr-10';
+      lock.style.color = '#bf6447';
+      entryLock.appendChild(lock);
+      entryTitle.appendChild(entryLock);
+    }
+
     entryTitle.appendChild(titleLink);
     blogDetail.appendChild(entryTitle);
 

--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -129,27 +129,36 @@ export async function boardDetail() {
       }
 
       // 보드 태그
-      const ulElement = document.createElement('ul');
+      if(data.board.tags.length === 0) {
+        const noTagsMessage = document.createElement('div');
+        noTagsMessage.textContent = '보드에 등록된 태그가 없습니다.';
+        noTagsMessage.classList.add('no-tags-message');
+        const boardTagsElement = document.querySelector('.board-tags');
+        boardTagsElement.appendChild(noTagsMessage);
+      }
+      else {
+        const ulElement = document.createElement('ul');
 
-      data.board.tags.forEach((tag) => {
-        const liElement = document.createElement('li');
+        data.board.tags.forEach((tag) => {
+          const liElement = document.createElement('li');
 
-        const aElement = document.createElement('a');
-        aElement.href = '#';
-        aElement.textContent = `${tag}`;
+          const aElement = document.createElement('a');
+          aElement.href = '#';
+          aElement.textContent = `${tag}`;
 
-        // aElement.appendChild(iElement);  <i> 요소를 <a> 요소의 자식으로 추가
-        liElement.appendChild(aElement); // <a> 요소를 <li> 요소의 자식으로 추가
-        ulElement.appendChild(liElement); // <li> 요소를 <ul>요 소의 자식으로 추가
-      });
+          liElement.appendChild(aElement); // <a> 요소를 <li> 요소의 자식으로 추가
+          ulElement.appendChild(liElement); // <li> 요소를 <ul>요 소의 자식으로 추가
+        });
 
-      // 최종적으로 생성된 HTML 코드 출력
-      const boardTagsElement = document.querySelector('.board-tags');
-      boardTagsElement.appendChild(ulElement);
+        // 최종적으로 생성된 HTML 코드 출력
+        const boardTagsElement = document.querySelector('.board-tags');
+        boardTagsElement.appendChild(ulElement);
+      }
 
       // 핀 목록
       const containerElement = document.querySelector('.pins-container');
 
+      // 등록된 핀이 없는 경우
       if (data.pins.length === 0) {
         const noPinsMessage = document.createElement('div');
         noPinsMessage.textContent = '보드에 등록된 핀이 없습니다.';
@@ -213,14 +222,17 @@ export async function boardDetail() {
 
           postElement.append(boxElement);
 
+          // 특정 핀 마우스오버시 스타일 추가
           postElement.addEventListener('mouseover', function () {
             postElement.classList.add('pins-hovered');
           });
 
+          // 특정 핀 마우스오버 해제시 스타일 제거
           postElement.addEventListener('mouseout', function () {
             postElement.classList.remove('pins-hovered');
           });
 
+          // 특정 핀 클릭 시 핀 상세보기 모달 표시
           postElement.addEventListener('click', function () {
             $('#myModal').modal('show');
             let place_id = pin.place_id;
@@ -286,14 +298,19 @@ export async function boardDetail() {
         commentDiv.appendChild(infoDiv);
 
         commentsSection.append(commentDiv);
-
+        
         // 댓글 삭제 아이콘 표시
         // 로그인된 유저와 댓글 작성자가 같은 경우
         if (comment.user.email === loggedInUserEmail) {
           const deleteIconDiv = document.createElement('div');
           deleteIconDiv.classList.add('fa', 'fa-times');
           infoDiv.appendChild(deleteIconDiv);
-
+          
+          // 댓글 삭제 아이콘 마우스오버시 스타일 추가
+          deleteIconDiv.addEventListener('mouseover', function () {
+            deleteIconDiv.style.cursor = 'pointer';
+          });
+          
           // 댓글 삭제 기능
           // 클릭 이벤트 추가
           deleteIconDiv.addEventListener('click', function () {

--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -106,7 +106,29 @@ export async function boardDetail() {
       boardTitleElement.textContent = data.board.title;
 
       // 보드 작성자
+      const userProfileLink = document.querySelector('.user-profile-link');
       const boardUserElement = document.querySelector('.board-userId');
+      
+      // 이메일 클릭 시 작성자 프로필로 이동
+      userProfileLink.addEventListener('click', function(event) {
+        const boardUserEmail = data.board.user.email;
+        event.preventDefault();
+
+        const boardUserPk = data.board.user.id;
+
+        let userProfileUrl;
+
+        if (loggedInUserEmail === boardUserEmail) {
+          userProfileUrl = '../html/user_info.html';
+        }
+        else {
+          userProfileUrl = `../html/user_info.html?pk=${boardUserPk}`;
+        }
+        
+        window.location.href = userProfileUrl;
+      });
+
+      // 보드 작성자 출력
       boardUserElement.textContent = data.board.user.email;
 
       // 보드 작성일
@@ -276,14 +298,23 @@ export async function boardDetail() {
         let h4Tag = document.createElement('h5');
         h4Tag.className = 'theme-color mb-20';
 
+        let aTag = document.createElement('a');
+        if (loggedInUserEmail === comment.user.email) {
+          aTag.href = '../html/user_info.html';
+        }
+        else {
+          const boardCommentUserPk = comment.user.id;
+          aTag.href = `../html/user_info.html?pk=${boardCommentUserPk}`;
+        }
+
         let textNode = document.createTextNode(comment.user.email);
+        aTag.appendChild(textNode);
+
         let spanTag = document.createElement('span');
-
         let dateNode = document.createTextNode(formatDate(comment.created_at));
-
         spanTag.appendChild(dateNode);
 
-        h4Tag.appendChild(textNode);
+        h4Tag.appendChild(aTag);
         h4Tag.appendChild(spanTag);
 
         let pElement = document.createElement('p');

--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -73,6 +73,11 @@ export async function boardDetail() {
   })
     .then((response) => response.json())
     .then((data) => {
+      // 핀이 존재하지 않는 보드의 경우 지도 미표시
+      if (data.pins.length === 0) {
+        document.querySelector(".entry-image.clearfix.map").style.display = 'none';
+      }
+      
       CURRENT_PINS.value = '';
       CURRENT_PINS.value = data.pins;
 

--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -150,72 +150,88 @@ export async function boardDetail() {
       // 핀 목록
       const containerElement = document.querySelector('.pins-container');
 
-      data.pins.forEach((pin, index) => {
-        const postElement = document.createElement('div');
-        postElement.classList.add('port-post', 'clearfix', 'bg-white');
+      if (data.pins.length === 0) {
+        const noPinsMessage = document.createElement('div');
+        noPinsMessage.textContent = '보드에 등록된 핀이 없습니다.';
+        noPinsMessage.classList.add('no-pins-message');
+        containerElement.appendChild(noPinsMessage);
+      }
+      else {
+        data.pins.forEach((pin, index) => {
+          const postElement = document.createElement('div');
+          postElement.classList.add('port-post', 'clearfix', 'bg-white');
 
-        if (index === 0) {
-          postElement.classList.add('mt-20');
-        } else {
-          postElement.classList.add('mt-40', 'mb-20');
-        }
-
-        const boxElement = document.createElement('div');
-        boxElement.classList.add('pins-box');
-
-        const photoDivElement = document.createElement('div');
-        photoDivElement.classList.add('port-post-photo');
-
-        const imgElement = document.createElement('img');
-        imgElement.src = pin.thumbnail_img;
-        imgElement.classList.add('pin-thumbnail-img');
-
-        photoDivElement.appendChild(imgElement);
-
-        const infoDivElement = document.createElement('div');
-        infoDivElement.classList.add('port-post-info');
-
-        const h3Element = document.createElement('h3');
-        h3Element.classList.add('theme-color');
-        h3Element.innerHTML = `<span>상호명: </span>${pin.title}`;
-
-        infoDivElement.appendChild(h3Element);
-
-        let pinsInfoDiv = document.createElement('div');
-        pinsInfoDiv.classList.add('pins-info');
-
-        ['category', 'new_address'].forEach((key) => {
-          if (pin[key]) {
-            let h5Element = document.createElement('h5');
-            let label = '';
-
-            if (key === 'category') {
-              label = '카테고리';
-            } else if (key === 'new_address') {
-              label = '주소';
-            }
-
-            h5Element.innerHTML = `<span>${label}: </span>${pin[key]}`;
-            pinsInfoDiv.append(h5Element);
+          if (index === 0) {
+            postElement.classList.add('mt-20');
+          } else {
+            postElement.classList.add('mt-40', 'mb-20');
           }
+
+          const boxElement = document.createElement('div');
+          boxElement.classList.add('pins-box');
+
+          const photoDivElement = document.createElement('div');
+          photoDivElement.classList.add('port-post-photo');
+
+          const imgElement = document.createElement('img');
+          imgElement.src = pin.thumbnail_img;
+          imgElement.classList.add('pin-thumbnail-img');
+
+          photoDivElement.appendChild(imgElement);
+
+          const infoDivElement = document.createElement('div');
+          infoDivElement.classList.add('port-post-info');
+
+          const h3Element = document.createElement('h3');
+          h3Element.classList.add('theme-color');
+          h3Element.innerHTML = `<span>상호명: </span>${pin.title}`;
+
+          infoDivElement.appendChild(h3Element);
+
+          let pinsInfoDiv = document.createElement('div');
+          pinsInfoDiv.classList.add('pins-info');
+
+          ['category', 'new_address'].forEach((key) => {
+            if (pin[key]) {
+              let h5Element = document.createElement('h5');
+              let label = '';
+
+              if (key === 'category') {
+                label = '카테고리';
+              } else if (key === 'new_address') {
+                label = '주소';
+              }
+
+              h5Element.innerHTML = `<span>${label}: </span>${pin[key]}`;
+              pinsInfoDiv.append(h5Element);
+            }
+          });
+
+          infoDivElement.append(pinsInfoDiv);
+
+          boxElement.append(photoDivElement, infoDivElement);
+
+          postElement.append(boxElement);
+
+          postElement.addEventListener('mouseover', function () {
+            postElement.classList.add('pins-hovered');
+          });
+
+          postElement.addEventListener('mouseout', function () {
+            postElement.classList.remove('pins-hovered');
+          });
+
+          postElement.addEventListener('click', function () {
+            $('#myModal').modal('show');
+            let place_id = pin.place_id;
+            console.log(place_id);
+            PIN_DETAIL.placeId = place_id;
+            pinDetail();
+          });
+
+          containerElement.appendChild(postElement);
         });
-
-        infoDivElement.append(pinsInfoDiv);
-
-        boxElement.append(photoDivElement, infoDivElement);
-
-        postElement.append(boxElement);
-
-        postElement.addEventListener('click', function () {
-          $('#myModal').modal('show');
-          let place_id = pin.place_id;
-          console.log(place_id);
-          PIN_DETAIL.placeId = place_id;
-          pinDetail();
-        });
-
-        containerElement.appendChild(postElement);
-      });
+      }
 
       // 댓글 목록
       var commentsSection = document.querySelector('.comments-container');


### PR DESCRIPTION
## 보드 전체 목록 출력시 비공개 보드 처리
- 로그인된 유저와 보드 작성자가 같을 경우, 공개/비공개 보드가 모두 표시
   - 비공개 보드인 경우 보드 이름 좌측에 자물쇠 아이콘 표시
   <img width="155px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/0807b719-b1f6-4c39-8098-57a54badd750">

- 로그인된 유저와 보드 작성자가 다를 경우, 공개 보드만 표시

**즉, 보드 전체 목록에는 본인이 만든 보드는 모두 출력, 다른 유저의 보드는 공개 보드만 출력** 

<br>

## UX, UI 개선 사항
- 보드 상세보기시 핀이 존재하지 않는 경우 지도 출력되지 않음, Pins 섹션에는 문구 출력
- 보드 상세보기시 태그가 존재하지 않는 경우 Tags 섹션에 문구 출력
   <img width="600px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/74a5604e-572a-41b9-8f24-69bd868397fa">

- 보드 상세보기의 핀 목록 중 특정 핀 섹션에 마우스오버시 css 추가
   - 마우스 커서 포인터로 변경과 배경 색상 추가
   <img width="600px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/68059b9e-4980-451d-808e-35e773fc3f4e">

-  보드 상세보기의 댓글 목록 중 댓글 삭제 아이콘 마우스오버시 css 추가
   - 마우스 커서 포인터로 변경
- 보드 상세보기의 작성자 이메일 클릭 또는 댓글 작성자 이메일 클릭시 해당 유저 프로필 페이지로 이동
   - 본인인 경우
   <img width="600px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/8c3d4c1e-1417-4cf7-827e-95fb82c824b5"> <br>
   - 다른 유저인 경우
        <img width="380px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/de121f58-63e4-4825-83bd-d3c2084d2a18">
