### PR TITLE
[FE] [BE] Board 태그 관련 기능 수정/추가, 비공개 보드 처리 

### DIFF
--- a/everyplace/board/views.py
+++ b/everyplace/board/views.py
@@ -292,17 +292,23 @@ class BoardSearchView(APIView):
         else:
             # 로그인된 사용자가 작성한 공개/비공개 보드
             user_boards = Board.objects.filter(user_id=request.user.id, is_deleted=False)
-            
-            if search_field == 'all':
-                user_boards_filtered = user_boards.filter(
-                    Q(title__icontains=search_term) | Q(tags__content__icontains=search_term)).distinct()
 
             # 로그인된 사용자가 작성자가 아닌 다른 사용자의 공개 보드
             public_boards_except_user_ones = Board.objects.exclude(user_id=request.user.id).filter(is_public=True, is_deleted=False)
-            
+
+            # 제목 또는 태그 내용으로 검색
             if search_field == 'all':
+                user_boards_filtered = user_boards.filter(
+                    Q(title__icontains=search_term) | Q(tags__content__icontains=search_term)).distinct()
                 public_boards_filtered_except_user_ones = public_boards_except_user_ones.filter(
                     Q(title__icontains=search_term) | Q(tags__content__icontains=search_term)).distinct()
+
+            # 태그 내용으로 검색
+            elif search_field == 'tag':
+                user_boards_filtered = user_boards.filter(
+                    tags__content__icontains=search_term).distinct()
+                public_boards_filtered_except_user_ones = public_boards_except_user_ones.filter(
+                    tags__content__icontains=search_term).distinct()
 
             # 결합
             queryset = (user_boards_filtered | public_boards_filtered_except_user_ones).distinct()

--- a/frontend/assets/html/tagged_board_list.html
+++ b/frontend/assets/html/tagged_board_list.html
@@ -535,6 +535,18 @@ header -->
             const titleLink = document.createElement('a');
             titleLink.setAttribute('href', '#');
             titleLink.textContent = board.title;
+
+            // 본인의 비공개 보드 표기
+            const entryLock = document.createElement('span');
+            if (board.is_public === false) {
+              const lock = document.createElement('i');
+              lock.className = 'fa fa-solid fa-lock mr-10';
+              lock.style.color = '#bf6447';
+              lock.style.fontSize = '22px';
+              entryLock.appendChild(lock);
+              entryTitle.appendChild(entryLock);
+            }
+            
             entryTitle.appendChild(titleLink);
             blogDetail.appendChild(entryTitle);
 

--- a/frontend/assets/html/tagged_board_list.html
+++ b/frontend/assets/html/tagged_board_list.html
@@ -13,7 +13,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1"
     />
-    <title>FavSpot - User Info</title>
+    <title>FavSpot - Tagged Board List</title>
 
     <!-- Favicon -->
     <link
@@ -179,8 +179,8 @@ header -->
           <div class="row">
             <div class="col-lg-12 col-md-12">
               <div class="section-title text-center">
-                <h6 class="">View Your Boards with Tag - <span class="tag-name"></span></h6>
-                <h2 class="title-effect mt-10">Tagged Your Board</h2>
+                <h6 class="">View Boards with Tag - <span class="tag-name"></span></h6>
+                <h2 class="title-effect mt-10">Tagged Board</h2>
               </div>
             </div>
           </div>
@@ -203,49 +203,9 @@ header -->
             </nav>
           </div>
           <div id="main" class="row">
-            <div class="col-lg-3">
-              <div class="sidebar-widget">
-                <div class="team team-round full-border">
-                  <div class="team-photo">
-                    <img
-                      id="profileImg"
-                      class="img-fluid mx-auto"
-                      style="object-fit: cover; width: 215px; height: 215px"
-                      src="https://everyplacetest.s3.ap-northeast-2.amazonaws.com/dev/user_default_clear.png"
-                      alt=""
-                    />
-                  </div>
-                  <div class="team-description">
-                    <div class="team-info">
-                      <h6 id="email"></h6>
-                      <span id="nickname"></span>
-                    </div>
-                    <div>
-                      <i class="fa fa-user"></i>
-                      <a id="followers" href="#">
-                        <span class="followers" class="fw-bold small"></span>
-                        <span class="small">followers</span>
-                      </a>
-                      <span>|</span>
-                      <a id="following" href="#">
-                        <span class="following" class="fw-bold small"></span>
-                        <span class="small">following</span>
-                      </a>
-                    </div>
-                    <div class="changeBtn"></div>
-                  </div>
-                </div>
-              </div>
-
-              <div class="sidebar-widget">
-                <h6 class="mt-40 mb-20">Tags</h6>
-                <div class="widget-tags">
-                  <ul id="tagList"></ul>
-                </div>
-              </div>
-            </div>
+            
             <!-- ================================== -->
-            <div id="boardlist" class="col-lg-9">
+            <div id="boardlist" class="col-lg-12">
               <div class="masonry columns-2">
                 <div class="grid-sizer"></div>
               </div>
@@ -399,123 +359,6 @@ header -->
           })
             .then((response) => response.json())
             .then((data) => {
-              // 가져온 사용자 데이터를 폼 필드에 채워줍니다.
-              const currentUserPk = data['results']['User']['id'];
-              const currentUser = data['results']['User']['email'];
-              const email = document.querySelector('#email');
-              email.textContent = currentUser;
-              const nickname = document.querySelector('#nickname');
-
-              if (data['results']['User']['nickname']) {
-                nickname.textContent = data['results']['User']['nickname'];
-              } else {
-                nickname.textContent = 'None';
-              }
-              const img = data['results']['User']['profile_img'];
-              const profileImg = document.getElementById('profileImg');
-              console.log('img', img, !!img, profileImg);
-              if (img) {
-                profileImg.src = img;
-              }
-
-              let followers = document.querySelector('.followers');
-              followers.textContent = data['results']['User']['followers'];
-              followers = document.querySelector('#followers');
-              followers.addEventListener('click', (event) => {
-                window.location.href = `follower.html?pk=${currentUserPk}`;
-              });
-
-              let following = document.querySelector('.following');
-              following.textContent = data['results']['User']['following'];
-              following = document.querySelector('#following');
-              following.addEventListener('click', (event) => {
-                window.location.href = `following.html?pk=${pk}`;
-              });
-
-              const button = document.createElement('a');
-              button.type = 'button';
-              button.classList.add('btn', 'btn-primary', 'mt-1');
-              button.style.display = 'block';
-              const button2 = document.createElement('a');
-              button2.type = 'button';
-              button2.classList.add('btn', 'btn-primary', 'mt-1');
-
-              // 좋아요한 보드 목록 버튼
-              const button3 = document.createElement('a');
-              button3.type = 'button';
-              button3.classList.add('btn', 'btn-primary', 'mt-1', 'liked-board-btn');
-
-              // 기존 요소에 버튼 추가
-              const changeBtnDiv = document.querySelector('.changeBtn');
-              const params = new URLSearchParams(window.location.search);
-              let followerPk = params.get('pk');
-
-              if ((requestUser === currentUser) | (requestUserPk === pk)) {
-                button.textContent = 'Profile Edit';
-                button.setAttribute('href', 'profile_edit.html');
-
-                button2.textContent = 'Pin List';
-                button2.style.display = 'block';
-                button2.setAttribute('href', 'pin_list.html');
-
-                button3.textContent = 'Liked Board';
-                button3.style.display = 'block';
-                button3.setAttribute('href', 'user_liked_board.html');
-
-                changeBtnDiv.appendChild(button2);
-              } else if (followingList.includes(currentUser)) {
-                button.textContent = 'Unfollow';
-                button.addEventListener('click', () => {
-                  fetch(`http://127.0.0.1:8000/user/follow/${followerPk}/`, {
-                    method: 'DELETE',
-                    credentials: 'include',
-                    headers: {
-                      'Content-Type': 'application/json',
-                    },
-                  })
-                    .then((response) => {
-                      if (response.status === 204) {
-                        location.reload(); // 페이지 새로고침
-                      } else {
-                        return response.json();
-                      }
-                    })
-                    .catch((error) => console.error('Error:', error));
-                });
-              } else {
-                button.textContent = 'Follow';
-                button.addEventListener('click', () => {
-                  fetch(`http://127.0.0.1:8000/user/follow/`, {
-                    method: 'POST',
-                    credentials: 'include',
-                    headers: {
-                      'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({ user_id: followerPk }),
-                  })
-                    .then((response) => {
-                      if (response.status === 201) {
-                        location.reload(); // 페이지 새로고침
-                      } else {
-                        return response.json();
-                      }
-                    })
-                    .catch((error) => console.error('Error:', error));
-                });
-              }
-              changeBtnDiv.appendChild(button);
-              changeBtnDiv.appendChild(button3);
-
-              const tags = data['results']['User']['tags'];
-              tags.forEach((tag) => {
-                const newLi = document.createElement('li');
-                const newTag = document.createElement('a');
-                newTag.setAttribute('href', 'user_tagged_board.html?tag=' + encodeURIComponent(tag));
-                newTag.textContent = tag;
-
-                newLi.appendChild(newTag);
-                tagList.appendChild(newLi);
-              });
 
               const parentElement =
                 document.querySelector('.masonry.columns-2');
@@ -541,7 +384,7 @@ header -->
               // 페이지 상단 안내 문구에 선택된 태그 값 표기
               document.querySelector('.tag-name').textContent = tag;
 
-              fetch(`http://127.0.0.1:8000/board/tag/?tag=${tag}`, {
+              fetch(`http://127.0.0.1:8000/board/search/?search_field=tag&search=${tag}`, {
                   credentials: 'include',
                   headers: {
                     'Content-Type': 'application/json',

--- a/frontend/assets/html/user_info.html
+++ b/frontend/assets/html/user_info.html
@@ -655,6 +655,18 @@ header -->
             const titleLink = document.createElement('a');
             titleLink.setAttribute('href', '#');
             titleLink.textContent = board.title;
+
+            // 본인의 비공개 보드 표기
+            const entryLock = document.createElement('span');
+            if (board.is_public === false) {
+              const lock = document.createElement('i');
+              lock.className = 'fa fa-solid fa-lock mr-10';
+              lock.style.color = '#bf6447';
+              lock.style.fontSize = '22px';
+              entryLock.appendChild(lock);
+              entryTitle.appendChild(entryLock);
+            }
+
             entryTitle.appendChild(titleLink);
             blogDetail.appendChild(entryTitle);
 

--- a/frontend/assets/html/user_liked_board.html
+++ b/frontend/assets/html/user_liked_board.html
@@ -669,6 +669,18 @@ header -->
             const titleLink = document.createElement('a');
             titleLink.setAttribute('href', '#');
             titleLink.textContent = board.title;
+
+            // 본인의 비공개 보드 표기
+            const entryLock = document.createElement('span');
+            if (board.is_public === false) {
+              const lock = document.createElement('i');
+              lock.className = 'fa fa-solid fa-lock mr-10';
+              lock.style.color = '#bf6447';
+              lock.style.fontSize = '22px';
+              entryLock.appendChild(lock);
+              entryTitle.appendChild(entryLock);
+            }
+            
             entryTitle.appendChild(titleLink);
             blogDetail.appendChild(entryTitle);
 

--- a/frontend/assets/html/user_tagged_board.html
+++ b/frontend/assets/html/user_tagged_board.html
@@ -692,6 +692,18 @@ header -->
             const titleLink = document.createElement('a');
             titleLink.setAttribute('href', '#');
             titleLink.textContent = board.title;
+
+            // 본인의 비공개 보드 표기
+            const entryLock = document.createElement('span');
+            if (board.is_public === false) {
+              const lock = document.createElement('i');
+              lock.className = 'fa fa-solid fa-lock mr-10';
+              lock.style.color = '#bf6447';
+              lock.style.fontSize = '22px';
+              entryLock.appendChild(lock);
+              entryTitle.appendChild(entryLock);
+            }
+            
             entryTitle.appendChild(titleLink);
             blogDetail.appendChild(entryTitle);
 

--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -165,7 +165,7 @@ export async function boardDetail() {
           const liElement = document.createElement('li');
 
           const aElement = document.createElement('a');
-          aElement.href = '#';
+          aElement.setAttribute('href', 'tagged_board_list.html?tag=' + encodeURIComponent(tag));
           aElement.textContent = `${tag}`;
 
           liElement.appendChild(aElement); // <a> 요소를 <li> 요소의 자식으로 추가


### PR DESCRIPTION
### 보드 목록의 태그 표기되도록 수정
- 메인 페이지에서 출력되는 보드 목록의 경우 각 보드당 태그가 2개까지 표기
- 2bc8f9c4d3f3874c874273e6a19e4717f43012aa & 7049d2d5e19bb686892fe52df78ccc29f9ef6050
<img width="180px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/7da769be-12ed-4316-9552-a9e6ae3ba4a1">

- 유저 정보 페이지에서 출력되는 보드 목록의 경우 각 보드당 태그가 4개까지 표기
- 7c35f66006faee05a49944b17aa4de30d397dbcb & 7049d2d5e19bb686892fe52df78ccc29f9ef6050
<img width="180px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/8f1c71d5-2fbb-41a2-a88c-f0429bbfd474">


### 태그 클릭 시 해당 태그를 가진 보드 목록 조회 기능 추가
- 보드 상세보기 페이지에서 특정 태그를 클릭 시 해당 태그를 가진 모든 보드 목록 조회 가능
<img width="500px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/25068129-80a4-4b97-8f10-16c74a85b65c">

- 유저 정보 페이지에서 특정 태그를 클릭 시 해당 태그를 가진 본인의 보드 목록 조회 가능
- b73fc2f90e4ce282e899aa86d5ec7d87698358b6 
<img width="500px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/e19b434a-e4e8-4ae5-af40-2a9cba900ad8"> <br>


### 비공개 보드 표기 일괄 처리
- 비공개 보드 표기를 위해 유저 정보 페이지(그 외 유저가 좋아요한 목록 페이지, 위에서 언급한 특정 태그를 가진 보드 목록 페이지들) 등에서 비공개 보드인 경우 자물쇠 아이콘을 추가하였습니다.
<img width="180px" alt="image" src="https://github.com/inslog94/FavSpot/assets/43246395/1c0eea75-c366-4a33-97d9-2e43766e1640">

---

- 이전 PR의 merge전에 보드 목록의 태그 표기되도록 수정 부분과 유저 정보 페이지에서 특정 태그를 클릭 시 해당 태그를 가진 본인의 보드 목록 조회 가능 부분을 commit하여 해당 부분은 현재 PR의  Files changed란에서 확인할 수 없는 점 참고하시고 양해 부탁드립니다.
- 커밋 링크를 해당 부분에 첨부하였으니 코드는 해당 링크에서 확인 해 주시면 감사하겠습니다.