### PR TITLE
알림 읽음 여부에 따른 처리

### DIFF
--- a/everyplace/notification/serializers.py
+++ b/everyplace/notification/serializers.py
@@ -7,5 +7,5 @@ class NotificationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Notification
-        fields = ['message', 'sender', 'receiver',
+        fields = ['id', 'message', 'sender', 'receiver',
                   'is_read', 'created_at', 'sender_email', 'related_url']

--- a/everyplace/notification/urls.py
+++ b/everyplace/notification/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import NotificationList
+from .views import NotificationList, NotificationReadMark
 
 app_name = 'notification'
 
 urlpatterns = [
-    path('', NotificationList.as_view(), name='list')
+    path('', NotificationList.as_view(), name='list'),
+    path('<int:pk>/read/', NotificationReadMark.as_view(), name='read'),
 ]

--- a/everyplace/notification/views.py
+++ b/everyplace/notification/views.py
@@ -19,3 +19,21 @@ class NotificationList(APIView):
         serializer = NotificationSerializer(all_notifications, many=True)
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+# 알림 읽음 여부 체크
+class NotificationReadMark(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, pk):
+        user = request.user
+
+        try:
+            notification = Notification.objects.get(pk=pk, receiver=user)
+        except Notification.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        notification.is_read = True
+        notification.save()
+
+        return Response(status=status.HTTP_200_OK)

--- a/frontend/assets/css/pin-list.css
+++ b/frontend/assets/css/pin-list.css
@@ -1,42 +1,45 @@
 .text-cell {
-    width: 350px; /* 원하는 너비로 설정 */
-    overflow: hidden;
-    text-overflow: ellipsis;
+  width: 350px; /* 원하는 너비로 설정 */
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .pin-cell {
-    width: 170px; /* 원하는 너비로 설정 */
-    overflow: hidden;
-    text-overflow: ellipsis;
+  width: 170px; /* 원하는 너비로 설정 */
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #edit-form {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    gap: 10px;
-  }
-  
-  #photoUpload {
-    width: 200px;
-    height: 40px;
-    border-radius: 5px;
-  }
-  
-  #textUpload {
-   width:400px;
-   padding-left :10px; 
-   resize:vertical ;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 10px;
+}
 
-  }
-  
-  .submitbtn {
-   background-color : indigo; 
-   color : white; 
-   padding :14px,20 px; 
-   margin :8 px, 0;
-   border:none ;
-   cursor:pointer; 
-   width: 100px;
-   height: 43px;
-  }
+#photoUpload {
+  width: 200px;
+  height: 40px;
+  border-radius: 5px;
+}
+
+#textUpload {
+  width: 400px;
+  padding-left: 10px;
+  resize: vertical;
+}
+
+.submitbtn {
+  background-color: indigo;
+  color: white;
+  padding: 14px, 20 px;
+  margin: 8 px, 0;
+  border: none;
+  cursor: pointer;
+  width: 100px;
+  height: 43px;
+}
+
+.read-notification {
+  background-color: #f0f0f0; /* 연한 회색 */
+}

--- a/frontend/assets/html/notification.html
+++ b/frontend/assets/html/notification.html
@@ -440,8 +440,25 @@ shop -->
         tableRow.appendChild(messageCell);
 
         messageLink.addEventListener("click", (event) => {
-          localStorage.setItem("selectedPk", data.related_url);
-          window.location.href = "board_detail.html";
+          event.preventDefault();
+          // is_read를 True로 변경하는 요청
+          fetch(`${url}/notification/${data.id}/read/`, {
+            method: "POST",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          })
+            .then((response) => {
+              if (!response.ok) {
+                throw new Error("적절하지 않은 응답입니다");
+              }
+
+              // 성공적으로 처리된 후 페이지 이동
+              localStorage.setItem("selectedPk", data.related_url);
+              window.location.href = "board_detail.html";
+            })
+            .catch((error) => console.error("error:", error));
         });
 
         // 보낸 유저 이메일 셀 생성

--- a/frontend/assets/html/notification.html
+++ b/frontend/assets/html/notification.html
@@ -417,6 +417,10 @@ shop -->
       function createTableRow(data) {
         const notification = data;
         const tableRow = document.createElement("tr");
+        // is_read 값에 따라 배경색 클래스 추가
+        if (data.is_read) {
+          tableRow.classList.add("read-notification");
+        }
 
         // 읽음 여부 셀 생성
         const readCell = document.createElement("td");

--- a/frontend/assets/js/maps/websocket.js
+++ b/frontend/assets/js/maps/websocket.js
@@ -31,13 +31,16 @@ fetch(`http://127.0.0.1:8000/user/me/`, {
         notifications.shift();
       }
 
+      // 새로운 알림이 도착했으므로 붉은 점 표시
+      document.querySelector(".notification-dot").style.display = "inline";
+
       // 기존 내용 초기화
       const notificationList = document.getElementById("notification-list");
       notificationList.innerHTML = "";
       // 최신 순으로 반복하여 li 요소 추가
       for (let i = notifications.length - 1; i >= 0; i--) {
         const listItem = document.createElement("li");
-        listItem.textContent = notifications[i];
+        listItem.textContent = `새 알림: ${notifications[i]}`;
         notificationList.appendChild(listItem);
       }
     });
@@ -60,3 +63,26 @@ fetch(`http://127.0.0.1:8000/user/me/`, {
 // }
 
 // export { sendWebSocketData };
+
+// 페이지 로드시 읽지않은 알림이 있는지 확인 후 없다면 붉은 점 표시
+document.addEventListener("DOMContentLoaded", function () {
+  fetch(`http://127.0.0.1:8000/notification/`, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      const unreadNotifications = data.filter(
+        (notification) => !notification.is_read
+      );
+
+      if (unreadNotifications.length > 0) {
+        document.querySelector(".notification-dot").style.display = "inline";
+      } else {
+        document.querySelector(".notification-dot").style.display = "none";
+      }
+    });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -148,6 +148,19 @@
                   style="object-fit: cover; width: 45px; height: 45px"
                 />
               </a>
+              <span
+                class="notification-dot"
+                style="
+                  position: absolute;
+                  top: -1px;
+                  right: -3px;
+                  width: 12px;
+                  height: 12px;
+                  background-color: red;
+                  border-radius: 50%;
+                  display: none;
+                "
+              ></span>
               <div class="cart">
                 <div class="cart-title">
                   <h6 id="headerEmail" class="uppercase mb-0"></h6>
@@ -158,9 +171,11 @@
                   </div>
                 </div>
                 <div class="cart-item">
+                  <div class="cart-name clearfix">
+                    <a href="assets/html/notification.html">Notification</a>
+                  </div>
                   <ul id="notification-list">
                     <!-- 알림 메시지 표시 공간 -->
-                    <li>알림이 없습니다</li>
                   </ul>
                 </div>
                 <div class="cart-total">


### PR DESCRIPTION
알림 리스트에서 알림 메시지 클릭 시 관련 링크로 이동함과 동시에 읽은 알림으로 바뀌도록 처리했습니다. 읽은 알림은 이제 알림 리스트에서 회색 배경을 가집니다. 아직 읽지 않은 알림이 있을 시 header의 프로필 사진 오른쪽 위에 붉은 점이 표시됩니다.

## 구현 내용
- 알림 객체의 is_read 필드를 True로 바꿔주는 view 구현
- 알림 리스트 페이지에서 알림 메시지 클릭 시 읽은 알림으로 바뀌도록 view 연결
- 알림 리스트에서 읽지 않은 알림과의 구분을 위해 읽은 알림의 행은 회색 배경으로 표시
- 읽지 않은 알림이 있을 시 header의 프로필 사진 오른쪽 위에 붉은 점으로 표시
- 실시간으로 알림을 받았을 때도 마찬가지로 붉은 점 표시

close #107 