### PR TITLE
세 가지 실시간 알림 기능 구현

### DIFF
--- a/frontend/assets/html/notification.html
+++ b/frontend/assets/html/notification.html
@@ -459,8 +459,14 @@ shop -->
               }
 
               // 성공적으로 처리된 후 페이지 이동
-              localStorage.setItem("selectedPk", data.related_url);
-              window.location.href = "board_detail.html";
+              if (data.related_url) {
+                // 보드 관련 알림인 경우
+                localStorage.setItem("selectedPk", data.related_url);
+                window.location.href = "board_detail.html";
+              } else {
+                // 팔로우 관련 알림인 경우
+                window.location.href = `user_info.html?pk=${data.sender}`;
+              }
             })
             .catch((error) => console.error("error:", error));
         });


### PR DESCRIPTION
구현이 예정되었던 네 가지 알림 중 첫 번째로 구현한 보드 댓글 알림을 제외한 나머지 알림 기능들을 구현했습니다.

## 구현 내용
- 상대 보드에 좋아요 등록 시 보드 주인에게 알림이 가는 기능 구현
- 누군가 나를 팔로우하면 알림이 오는 기능 구현
- 좋아요한 보드에 보드 주인이 핀 추가시 알림이 오는 기능 구현
- 알림 리스트 페이지에서 알림 메시지 클릭 시 보드 관련 알림이면 관련된 보드 상세 페이지로, 팔로우 알림이면 팔로우한 유저 정보 페이지로 이동하도록 처리

close #88 