### PR TITLE
알림 삭제 기능 구현 및 알림 관련 UI 수정

### DIFF
--- a/everyplace/notification/consumers.py
+++ b/everyplace/notification/consumers.py
@@ -72,7 +72,7 @@ def send_comment_notification(sender, instance, created, **kwargs):
                 receiver=instance.board_id.user_id,
                 is_read=False,
                 is_deleted=False,
-                related_url=f"{instance.board_id.id}",
+                related_url=f"{instance.board_id.id},commented",
             )
 
 
@@ -103,7 +103,7 @@ def send_like_notification(sender, instance, created, **kwargs):
                 receiver=instance.board_id.user_id,
                 is_read=False,
                 is_deleted=False,
-                related_url=f"{instance.board_id.id}",
+                related_url=f"{instance.board_id.id},liked",
             )
 
 
@@ -130,7 +130,7 @@ def send_follow_notification(sender, instance, created, **kwargs):
             receiver=instance.followed_user,
             is_read=False,
             is_deleted=False,
-            related_url="",
+            related_url=",followed",
         )
 
 
@@ -162,5 +162,5 @@ def send_likedboard_addpin_notification(sender, instance, action, pk_set, **kwar
                     receiver=like.user_id,
                     is_read=False,
                     is_deleted=False,
-                    related_url=f"{board.id}"
+                    related_url=f"{board.id},updated"
                 )

--- a/everyplace/notification/consumers.py
+++ b/everyplace/notification/consumers.py
@@ -55,7 +55,7 @@ def send_comment_notification(sender, instance, created, **kwargs):
         # 댓글 단 보드의 주인과 댓글 단 유저가 다를 시 알림 보냄
         if board_owner_id != instance.user_id.id:
             channel_layer = get_channel_layer()
-            message = f"'{instance.board_id.title}' 보드에 새 댓글이 달렸습니다"
+            message = f"'{instance.user_id.email}'님이 '{instance.board_id.title}' 보드에 댓글을 달았습니다"
 
             # WebSocket 연결을 통해 보드 주인에게 알림
             async_to_sync(channel_layer.group_send)(

--- a/everyplace/notification/serializers.py
+++ b/everyplace/notification/serializers.py
@@ -3,9 +3,9 @@ from .models import Notification
 
 
 class NotificationSerializer(serializers.ModelSerializer):
-    sender_email = serializers.ReadOnlyField(source='sender.email')
+    sender_profile_img = serializers.ImageField(source='sender.profile_img')
 
     class Meta:
         model = Notification
         fields = ['id', 'message', 'sender', 'receiver',
-                  'is_read', 'created_at', 'sender_email', 'related_url']
+                  'is_read', 'created_at', 'sender_profile_img', 'related_url']

--- a/everyplace/notification/urls.py
+++ b/everyplace/notification/urls.py
@@ -1,9 +1,13 @@
 from django.urls import path
-from .views import NotificationList, NotificationReadMark
+from . import views
 
 app_name = 'notification'
 
 urlpatterns = [
-    path('', NotificationList.as_view(), name='list'),
-    path('<int:pk>/read/', NotificationReadMark.as_view(), name='read'),
+    # 알림 리스트 조회
+    path('', views.NotificationList.as_view(), name='list'),
+    # 알림 읽음 처리
+    path('<int:pk>/read/', views.NotificationReadMark.as_view(), name='read'),
+    # 알림 삭제
+    path('<int:pk>/', views.NotificationDelete.as_view(), name='delete'),
 ]

--- a/frontend/assets/css/pin-list.css
+++ b/frontend/assets/css/pin-list.css
@@ -2,6 +2,7 @@
   width: 350px; /* 원하는 너비로 설정 */
   overflow: hidden;
   text-overflow: ellipsis;
+  word-break: keep-all;
 }
 
 .pin-cell {

--- a/frontend/assets/html/notification.html
+++ b/frontend/assets/html/notification.html
@@ -203,6 +203,7 @@ shop -->
                       <tr>
                         <th>Read</th>
                         <th>Message</th>
+                        <th>Type</th>
                         <th>Sender</th>
                         <th>Time</th>
                         <th>Delete</th>
@@ -459,10 +460,11 @@ shop -->
                 throw new Error("적절하지 않은 응답입니다");
               }
 
+              const relatedId = data.related_url.split(",")[0];
               // 성공적으로 처리된 후 페이지 이동
-              if (data.related_url) {
+              if (relatedId) {
                 // 보드 관련 알림인 경우
-                localStorage.setItem("selectedPk", data.related_url);
+                localStorage.setItem("selectedPk", relatedId);
                 window.location.href = "board_detail.html";
               } else {
                 // 팔로우 관련 알림인 경우
@@ -471,6 +473,14 @@ shop -->
             })
             .catch((error) => console.error("error:", error));
         });
+
+        // 알림 종류 셀 생성
+        const typeCell = document.createElement("td");
+        typeCell.classList.add("description", "pt-10", "pb-10", "pin-cell");
+        const typeLink = document.createElement("div");
+        typeLink.textContent = data.related_url.split(",")[1];
+        typeCell.appendChild(typeLink);
+        tableRow.appendChild(typeCell);
 
         // 보낸 유저 이메일 셀 생성
         const senderCell = document.createElement("td");

--- a/frontend/assets/html/notification.html
+++ b/frontend/assets/html/notification.html
@@ -205,6 +205,7 @@ shop -->
                         <th>Message</th>
                         <th>Sender</th>
                         <th>Time</th>
+                        <th>Delete</th>
                       </tr>
                     </thead>
                     <tbody id="notificationList"></tbody>
@@ -508,6 +509,41 @@ shop -->
         timeLink.textContent = timeText;
         timeCell.appendChild(timeLink);
         tableRow.appendChild(timeCell);
+
+        // 삭제 버튼 셀 생성
+        const deleteCell = document.createElement("td");
+        deleteCell.classList.add("td-quantity", "pt-10", "pb-10");
+
+        const deleteButton = document.createElement("button");
+        deleteButton.className = "btn btn-danger";
+        deleteButton.textContent = "X";
+
+        /// 삭제 버튼 클릭 이벤트
+        deleteButton.addEventListener("click", () => {
+          if (confirm("이 리뷰를 삭제하시겠습니까?")) {
+            fetch(`${url}/notification/${data.id}/`, {
+              method: "DELETE",
+              credentials: "include",
+              headers: {
+                "Content-Type": "application/json",
+              },
+            })
+              .then((response) => {
+                if (response.status === 204) {
+                  tableRow.remove();
+                  window.alert("알림을 삭제했습니다.");
+                } else if (response.status === 403) {
+                  window.alert("알림은 본인만 삭제할 수 있습니다.");
+                }
+              })
+              .catch((error) => {
+                console.error("삭제시 문제가 발생했습니다:", error);
+              });
+          }
+        });
+
+        deleteCell.appendChild(deleteButton);
+        tableRow.appendChild(deleteCell);
 
         return tableRow;
       }

--- a/frontend/assets/html/notification.html
+++ b/frontend/assets/html/notification.html
@@ -429,9 +429,9 @@ shop -->
         readCell.classList.add("description", "pt-10", "pb-10");
         const readLink = document.createElement("div");
         if (data.is_read == true) {
-          readLink.textContent = "읽음";
+          readLink.innerHTML = '<i class="fa fa-envelope-open-o"></i>';
         } else {
-          readLink.textContent = "안읽음";
+          readLink.innerHTML = '<i class="fa fa-envelope"></i>';
         }
         readCell.appendChild(readLink);
         tableRow.appendChild(readCell);
@@ -485,9 +485,19 @@ shop -->
         // 보낸 유저 이메일 셀 생성
         const senderCell = document.createElement("td");
         senderCell.classList.add("description", "pt-10", "pb-10", "pin-cell");
-        const senderLink = document.createElement("a");
-        senderLink.href = "#";
-        senderLink.textContent = data.sender_email;
+        const senderLink = document.createElement("img");
+        senderLink.classList.add("img-fluid");
+        senderLink.style.width = "75px";
+        senderLink.style.height = "75px";
+        senderLink.style.borderRadius = "50%";
+        senderLink.style.cursor = "pointer";
+        if (data.sender_profile_img) {
+          senderLink.src = data.sender_profile_img;
+        } else {
+          senderLink.src =
+            "https://everyplacetest.s3.ap-northeast-2.amazonaws.com/dev/user_default_clear.png";
+        }
+        senderLink.alt = "";
         senderCell.appendChild(senderLink);
         tableRow.appendChild(senderCell);
 

--- a/frontend/assets/js/maps/websocket.js
+++ b/frontend/assets/js/maps/websocket.js
@@ -33,6 +33,7 @@ fetch(`http://127.0.0.1:8000/user/me/`, {
 
       // 새로운 알림이 도착했으므로 붉은 점 표시
       document.querySelector(".notification-dot").style.display = "inline";
+      document.querySelector("#notification-div").style.display = "flex";
 
       // 기존 내용 초기화
       const notificationList = document.getElementById("notification-list");
@@ -40,7 +41,10 @@ fetch(`http://127.0.0.1:8000/user/me/`, {
       // 최신 순으로 반복하여 li 요소 추가
       for (let i = notifications.length - 1; i >= 0; i--) {
         const listItem = document.createElement("li");
-        listItem.textContent = `새 알림: ${notifications[i]}`;
+        listItem.className = "ms-3";
+        listItem.style.listStyleType = "disc";
+        listItem.style.wordBreak = "keep-all";
+        listItem.textContent = `${notifications[i]}`;
         notificationList.appendChild(listItem);
       }
     });
@@ -52,17 +56,6 @@ fetch(`http://127.0.0.1:8000/user/me/`, {
   .catch((error) => {
     console.error("Error:", error);
   });
-
-// 데이터를 websocket 서버로 보내는 함수(채팅 기능)
-// function sendWebSocketData(data) {
-//   if (socket && socket.readyState === WebSocket.OPEN) {
-//     socket.send(JSON.stringify(data));
-//   } else {
-//     console.error("WebSocket connection is not open.");
-//   }
-// }
-
-// export { sendWebSocketData };
 
 // 페이지 로드시 읽지않은 알림이 있는지 확인 후 없다면 붉은 점 표시
 document.addEventListener("DOMContentLoaded", function () {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -174,9 +174,17 @@
                   <div class="cart-name clearfix">
                     <a href="assets/html/notification.html">Notification</a>
                   </div>
-                  <ul id="notification-list">
-                    <!-- 알림 메시지 표시 공간 -->
-                  </ul>
+                </div>
+                <div
+                  class="cart-item"
+                  id="notification-div"
+                  style="display: none"
+                >
+                  <div class="cart-name clearfix">
+                    <ul id="notification-list">
+                      <!-- 알림 메시지 표시 공간 -->
+                    </ul>
+                  </div>
                 </div>
                 <div class="cart-total">
                   <a class="button" href="assets/html/profile_edit.html"


### PR DESCRIPTION
알림 삭제 기능을 구현했습니다. 그리고 전반적인 알림 관련 UI를 수정했습니다.

## 구현 내용
- 알림 삭제 기능 구현, 알림 리스트 페이지에서 삭제 버튼을 눌러 삭제 가능
- 알림 리스트 페이지에서 알림 종류를 알려주는 열 추가 - commented, liked, followed, updated 네 가지로 구성
- 읽음 여부를 아이콘으로 변경
- 발신자의 이메일을 표시하던 부분을 발신자의 프로필 사진으로 대체. 바로가기 링크는 유지
![image](https://github.com/inslog94/FavSpot/assets/131739343/18e389ad-dbc2-4cef-b379-b1262f61383b)

- header에서 실시간 알림이 표시되는 칸을 Notification 버튼 칸과 분리

Before|After|
:---:|:---:|
![화면 캡처 2023-09-15 140018](https://github.com/inslog94/FavSpot/assets/131739343/ad4e45b3-f608-4954-8ee1-e512f261bd3c) | ![image](https://github.com/inslog94/FavSpot/assets/131739343/4496eb1c-322d-4f1b-b877-7abb69da62cd)

close #113 