### PR TITLE
[FE] [BE] 특정 유저가 좋아요한 보드 목록 조회 기능, 보드 목록 정렬 기능 추가, 예외처리 및 작은 에러나 세부 요소 코드 수정

### DIFF
--- a/everyplace/app/middleware.py
+++ b/everyplace/app/middleware.py
@@ -1,4 +1,6 @@
 from rest_framework.exceptions import PermissionDenied
+from rest_framework import status
+from django.http import JsonResponse
 
 class CookieToAuthorizationMiddleware:
     def __init__(self, get_response):
@@ -29,5 +31,8 @@ class Convert403to401Middleware:
                     response.status_code = 401
             except AttributeError:
                 pass
+
+        if response.status_code == 401:
+            response = JsonResponse({'error': '로그인하지 않은 사용자는 이용할 수 없습니다.'}, status=status.HTTP_401_UNAUTHORIZED)
 
         return response

--- a/everyplace/app/settings.py
+++ b/everyplace/app/settings.py
@@ -100,14 +100,11 @@ REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
-# SPECTACULAR_SETTINGS = {
-#     'SERVE_URL_PATTERN': [
-#         '^/board/$',  # /board/에 해당하는 URL 패턴
-#     ],
-#     'SERVE_URL_METHODS': {
-#         '^/board/$': ['GET', 'POST'],  # /board/ URL에 대한 허용할 메소드 목록 설정
-#     },
-# }
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'FavSpot API Document',  # API 제목 설정
+    'DESCRIPTION': 'drf-spectacular를 이용하여 만든 FavSpot의 API 문서입니다.',
+    "SCHEMA_PATH": os.path.join(BASE_DIR, "schema.json"),
+}
 
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',

--- a/everyplace/board/serializers.py
+++ b/everyplace/board/serializers.py
@@ -23,7 +23,7 @@ class BoardSerializer(serializers.ModelSerializer):
 
     # 유저 정보 추가
     def get_user(self, obj):
-        return UserSerializer(obj.user_id).data
+        return UserSerializer(obj.user_id).data['email']
     
     # 태그들의 content 값 리스트 형태로 추가
     def get_tags(self, obj):
@@ -37,11 +37,14 @@ class BoardCommentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = BoardComment
-        fields = ('id', 'board_id', 'user_id', 'user', 'content', 'created_at', 'is_deleted')
+        fields = ('id', 'user', 'board_id', 'user', 'content', 'created_at', 'is_deleted')
 
     # 유저 정보 추가
     def get_user(self, obj):
-        return UserSerializer(obj.user_id).data
+        serializer = UserSerializer(obj.user_id).data
+        comment_user = {"id": serializer['id'], 'email': serializer['email'], 'profile_img': serializer['profile_img']}
+
+        return comment_user
 
 
 # BoardLike

--- a/frontend/assets/html/board_detail.html
+++ b/frontend/assets/html/board_detail.html
@@ -329,6 +329,7 @@
       .no-pins-message {
         display: flex;
         justify-content: center;
+        text-align: center;
       }
 
       .pins-hovered {
@@ -1012,7 +1013,7 @@
              // 등록된 핀이 없는 경우
             if (data.pins.length === 0) {
               const noPinsMessage = document.createElement('div');
-              noPinsMessage.textContent = '보드에 등록된 핀이 없습니다.';
+              noPinsMessage.innerHTML = '보드에 등록된 핀이 없습니다. <br>메인페이지에서 해당 보드에 핀을 추가할 수 있습니다.';
               noPinsMessage.classList.add('no-pins-message');
               containerElement.appendChild(noPinsMessage);
             }

--- a/frontend/assets/html/follower.html
+++ b/frontend/assets/html/follower.html
@@ -175,12 +175,6 @@ shop -->
                     </div>
                   </div>
 
-                  <div class="sidebar-widget">
-                    <h6 class="mt-40 mb-20">Tags</h6>
-                    <div class="widget-tags">
-                      <ul id="tagList"></ul>
-                    </div>
-                  </div>
                 </div>
                 <div class="table-responsive col-lg-9">
                   <table class="table">

--- a/frontend/assets/html/following.html
+++ b/frontend/assets/html/following.html
@@ -176,13 +176,6 @@ shop -->
                       </div>
                     </div>
                   </div>
-
-                  <div class="sidebar-widget">
-                    <h6 class="mt-40 mb-20">Tags</h6>
-                    <div class="widget-tags">
-                      <ul id="tagList"></ul>
-                    </div>
-                  </div>
                 </div>
                 <div class="table-responsive col-lg-9">
                   <table class="table">

--- a/frontend/assets/html/pin_list.html
+++ b/frontend/assets/html/pin_list.html
@@ -188,13 +188,6 @@ shop -->
                       </div>
                     </div>
                   </div>
-
-                  <div class="sidebar-widget">
-                    <h6 class="mt-40 mb-20">Tags</h6>
-                    <div class="widget-tags">
-                      <ul id="tagList"></ul>
-                    </div>
-                  </div>
                 </div>
                 <!-- 리스트 -->
                 <div class="table-responsive col-lg-9">

--- a/frontend/assets/html/user_info.html
+++ b/frontend/assets/html/user_info.html
@@ -89,6 +89,9 @@
         color: black;
         border: 2px solid transparent;
         box-shadow: none !important;
+        display: flex !important;
+        justify-content: center;
+        align-items: center;
       }
 
       .board-plus-text:hover {
@@ -104,6 +107,9 @@
 
       .fa-plus {
         font-size: 20px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
 
       /* 보드 생성 모달 스타일 */
@@ -620,6 +626,16 @@ header -->
           if (!pk) {
             pk = 'me';
           }
+
+          // 보드 생성 버튼을 숨기거나 표시하는 부분
+          const createBoardButton = document.querySelector('.btn.btn-primary.board-plus-text');
+
+          if (requestUserPk !== pk && pk !== 'me') { // 현재 사용자와 페이지 주인이 다를 경우
+            createBoardButton.style.display = 'none'; // 버튼 숨기기
+          } else {
+            createBoardButton.style.display = 'block'; // 버튼 표시하기
+          }
+
           const tagList = document.getElementById('tagList');
           fetch(`http://127.0.0.1:8000/user/${pk}/`, {
             method: 'GET',
@@ -664,6 +680,7 @@ header -->
               button.type = 'button';
               button.classList.add('btn', 'btn-primary', 'mt-1');
               button.style.display = 'block';
+              
               const button2 = document.createElement('a');
               button2.type = 'button';
               button2.classList.add('btn', 'btn-primary', 'mt-1');
@@ -688,11 +705,16 @@ header -->
 
                 button3.textContent = 'Liked Board';
                 button3.style.display = 'block';
-                button3.setAttribute('href', 'user_liked_board.html');
+                button3.setAttribute('href', `user_liked_board.html?pk=${requestUserPk}`);
 
                 changeBtnDiv.appendChild(button2);
               } else if (followingList.includes(currentUser)) {
                 button.textContent = 'Unfollow';
+
+                button3.textContent = 'Liked Board';
+                button3.style.display = 'block';
+                button3.setAttribute('href', `user_liked_board.html?pk=${pk}`);
+
                 button.addEventListener('click', () => {
                   fetch(`http://127.0.0.1:8000/user/follow/${followerPk}/`, {
                     method: 'DELETE',
@@ -712,6 +734,11 @@ header -->
                 });
               } else {
                 button.textContent = 'Follow';
+
+                button3.textContent = 'Liked Board';
+                button3.style.display = 'block';
+                button3.setAttribute('href', `user_liked_board.html?pk=${pk}`);
+
                 button.addEventListener('click', () => {
                   fetch(`http://127.0.0.1:8000/user/follow/`, {
                     method: 'POST',

--- a/frontend/assets/html/user_info.html
+++ b/frontend/assets/html/user_info.html
@@ -89,7 +89,7 @@
         color: black;
         border: 2px solid transparent;
         box-shadow: none !important;
-        display: flex !important;
+        display: flex;
         justify-content: center;
         align-items: center;
       }
@@ -633,7 +633,7 @@ header -->
           if (requestUserPk !== pk && pk !== 'me') { // 현재 사용자와 페이지 주인이 다를 경우
             createBoardButton.style.display = 'none'; // 버튼 숨기기
           } else {
-            createBoardButton.style.display = 'block'; // 버튼 표시하기
+            createBoardButton.style.display = 'flex'; // 버튼 표시하기
           }
 
           const tagList = document.getElementById('tagList');

--- a/frontend/assets/html/user_liked_board.html
+++ b/frontend/assets/html/user_liked_board.html
@@ -226,12 +226,6 @@ header -->
                 </div>
               </div>
 
-              <div class="sidebar-widget">
-                <h6 class="mt-40 mb-20">Tags</h6>
-                <div class="widget-tags">
-                  <ul id="tagList"></ul>
-                </div>
-              </div>
             </div>
             <!-- ================================== -->
             <div id="boardlist" class="col-lg-9">
@@ -513,17 +507,6 @@ header -->
               }
               changeBtnDiv.appendChild(button);
               changeBtnDiv.appendChild(button3);
-
-              const tags = data['results']['User']['tags'];
-              tags.forEach((tag) => {
-                const newLi = document.createElement('li');
-                const newTag = document.createElement('a');
-                newTag.setAttribute('href', 'user_tagged_board.html?tag=' + encodeURIComponent(tag));
-                newTag.textContent = tag;
-
-                newLi.appendChild(newTag);
-                tagList.appendChild(newLi);
-              });
 
               const parentElement =
                 document.querySelector('.masonry.columns-2');

--- a/frontend/assets/html/user_liked_board.html
+++ b/frontend/assets/html/user_liked_board.html
@@ -74,8 +74,8 @@
       }
 
       /* 좋아요한 보드 목록 버튼 스타일 */
-      .liked-board-btn {
-        background-color: #ffc107;
+      .go-back-btn {
+        background-color: #b18ec4;
         border: none;
       }
     </style>
@@ -432,7 +432,7 @@ header -->
               // 좋아요한 보드 목록 버튼
               const button3 = document.createElement('a');
               button3.type = 'button';
-              button3.classList.add('btn', 'btn-primary', 'mt-1', 'liked-board-btn');
+              button3.classList.add('btn', 'btn-primary', 'mt-1', 'go-back-btn');
 
               // 기존 요소에 버튼 추가
               const changeBtnDiv = document.querySelector('.changeBtn');
@@ -447,13 +447,24 @@ header -->
                 button2.style.display = 'block';
                 button2.setAttribute('href', 'pin_list.html');
 
-                button3.textContent = 'Liked Board';
+                button3.textContent = 'Go Back';
                 button3.style.display = 'block';
-                button3.setAttribute('href', 'user_liked_board.html');
+                button3.addEventListener('click', function(e) {
+                    e.preventDefault();  // 기본 링크 클릭 동작 방지
+                    window.history.back();
+                });
 
                 changeBtnDiv.appendChild(button2);
               } else if (followingList.includes(currentUser)) {
                 button.textContent = 'Unfollow';
+
+                button3.textContent = 'Go Back';
+                button3.style.display = 'block';
+                button3.addEventListener('click', function(e) {
+                    e.preventDefault();  // 기본 링크 클릭 동작 방지
+                    window.history.back();
+                });
+
                 button.addEventListener('click', () => {
                   fetch(`http://127.0.0.1:8000/user/follow/${followerPk}/`, {
                     method: 'DELETE',
@@ -473,6 +484,14 @@ header -->
                 });
               } else {
                 button.textContent = 'Follow';
+
+                button3.textContent = 'Go Back';
+                button3.style.display = 'block';
+                button3.addEventListener('click', function(e) {
+                    e.preventDefault();  // 기본 링크 클릭 동작 방지
+                    window.history.back();
+                });
+
                 button.addEventListener('click', () => {
                   fetch(`http://127.0.0.1:8000/user/follow/`, {
                     method: 'POST',
@@ -518,7 +537,10 @@ header -->
               let currentPage = 1;
 
               // 유저가 좋아요한 보드 목록 가져오기 위한 통신
-              fetch('http://127.0.0.1:8000/board/like/', {
+              const paramsUserId = new URLSearchParams(window.location.search);
+              let userId = params.get('pk');
+
+              fetch(`http://127.0.0.1:8000/board/like/${userId}`, {
                   credentials: 'include',
                   headers: {
                     'Content-Type': 'application/json',

--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -93,7 +93,7 @@ export async function boardDetail() {
       // 보드 수정 / 삭제 아이콘 표시
       // 로그인된 유저와 보드 작성자가 같은 경우
       const settingsBox = document.querySelector('.settings-box');
-      const boardUserEmail = data.board.user.email;
+      const boardUserEmail = data.board.user;
 
       if (loggedInUserEmail === boardUserEmail) {
         settingsBox.style.display = 'block';
@@ -111,10 +111,10 @@ export async function boardDetail() {
       
       // 이메일 클릭 시 작성자 프로필로 이동
       userProfileLink.addEventListener('click', function(event) {
-        const boardUserEmail = data.board.user.email;
+        const boardUserEmail = data.board.user;
         event.preventDefault();
 
-        const boardUserPk = data.board.user.id;
+        const boardUserPk = data.board.user_id;
 
         let userProfileUrl;
 
@@ -129,7 +129,7 @@ export async function boardDetail() {
       });
 
       // 보드 작성자 출력
-      boardUserElement.textContent = data.board.user.email;
+      boardUserElement.textContent = data.board.user;
 
       // 보드 작성일
       const boardCreatedAtElement = document.querySelector('.board-createdAt');


### PR DESCRIPTION
### 추가 구현한 기능
- 다른 특정 유저가 좋아요한 보드 목록 조회 기능 추가
   - 본인의 정보 페이지 또는 다른 유저의 정보 페이지에서 해당 유저가 좋아요한 보드 목록을 조회할 수 있습니다.
- 보드 목록 정렬 기능 추가
   - 최신순, 좋아요 개수순, 핀 개수순으로 보드 목록을 정렬 할 수 있습니다. (key=sort, value=pin/like/created(default입니다))

### 개선 사항
- 핀이 존재하지 않는 보드는 보드 목록 조회 시 제외
   - 보드 전체 목록 조회와 키워드 검색 시 보드 목록 결과 조회에 이 내용이 적용됩니다.
- 보드 상세보기 요청 시 필요한 응답 값만 반환하여 이용하도록 코드 수정
   - serializer에서 필요한 필드의 값들만 담아 반환하도록 수정하였습니다. 

### 수정 내용
- 보드 생성은 본인의 유저 정보 페이지에서만 가능하도록 수정
- 상세한 에러 처리 코드 추가 및 API 문서와 에러 처리 통일을 위한 코드 수정 (보드앱의 뷰)

### API 문서 관련
- API 문서 제목과 설명 추가
   - SPECTACULAR_SETTINGS을 이용하였고, Swagger UI의 최상단에서 이 내용을 확인할 수 있습니다.