### PR TITLE
핀이 저장되지 않은 장소의 상세보기 페이지에서의 핀 저장 기능 추가, 핀 저장 관련 전반적인 에러 수정

### DIFF
--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -236,7 +236,7 @@ export async function boardDetail(data) {
         $('#myModal').modal('show');
         let place_id = pin.place_id;
         console.log(place_id);
-        PIN_DETAIL.placeId = place_id;
+        PIN_DETAIL.place_id = place_id;
         pinDetail();
       });
 

--- a/frontend/assets/js/maps/pin.js
+++ b/frontend/assets/js/maps/pin.js
@@ -118,7 +118,7 @@ export function setMarkersFromAPI(dataList) {
     pin.categoryGroupCode = data.category_group_code;
     pin.categoryGroupName = data.category_group_name;
     pin.categoryName = data.categoryName;
-    pin.placeId = data.id;
+    pin.place_id = data.id;
     pin.phone = data.phone;
     pin.placeURL = data.place_url;
     pin.roadAddressName = data.road_address_name;
@@ -168,7 +168,7 @@ export function setMarkersFromServer(dataList) {
 
     data.categoryGroupName = data.category;
     data.position = new kakao.maps.LatLng(positions[0], positions[1]);
-    data.placeId = data.place_id;
+    data.place_id = data.place_id;
     data.lat = positions[0];
     data.lng = positions[1];
     data.roadAddressName = data.new_address;
@@ -190,7 +190,7 @@ export function setMarkerFromServer(data) {
 
   data.categoryGroupName = data.category;
   data.position = new kakao.maps.LatLng(positions[0], positions[1]);
-  data.placeId = data.place_id;
+  data.place_id = data.place_id;
   data.lat = positions[0];
   data.lng = positions[1];
   data.roadAddressName = data.new_address;
@@ -309,7 +309,7 @@ export async function displayPinOverlay(markerInfo) {
 
   // 해당 핀의 썸네일 여부 처리
   let pinThumbnail;
-  let pinContent = await getPinContentsFromServer(markerInfo.placeId);
+  let pinContent = await getPinContentsFromServer(markerInfo.place_id);
   let boxHeight = 170;
   let contentHeight = 160;
 
@@ -399,7 +399,7 @@ export async function displayPinOverlay(markerInfo) {
       PIN_DETAIL.old_address,
       PIN_DETAIL.lat_lng;
     PIN_DETAIL.category = markerInfo.categoryGroupName;
-    PIN_DETAIL.placeId = markerInfo.placeId;
+    PIN_DETAIL.place_id = markerInfo.place_id;
     PIN_DETAIL.title = markerInfo.title;
     PIN_DETAIL.thumbnail_img = pinThumbnail;
     PIN_DETAIL.new_address = markerInfo.roadAddressName;
@@ -442,7 +442,7 @@ function displayBoardsOnOverlay(markerInfo) {
 
     // 해당 핀이 보드에 생성된 경우 '생성됨' 처리
     for (let i = 0; i < board.pins.length; i++) {
-      if (board.pins[i] == markerInfo.placeId) {
+      if (board.pins[i] == markerInfo.place_id) {
         pinSaveBtn.innerText = '생성됨';
         pinSaveBtn.classList.remove('pin_save_btn');
         pinSaveBtn.classList.add('pin_saved_btn');

--- a/frontend/assets/js/maps/pinDetail.js
+++ b/frontend/assets/js/maps/pinDetail.js
@@ -58,6 +58,7 @@ export function pinDetail() {
         if (!response.ok) {
           // 가져온 데이터로 상세보기 정보 표시하기
           createPlaceInfo();
+          pinData = PIN_DETAIL; // 데이터 저장
           throw new Error('NO PIN');
         }
         return response.json();

--- a/frontend/assets/js/maps/pinDetail.js
+++ b/frontend/assets/js/maps/pinDetail.js
@@ -302,9 +302,11 @@ export function pinDetail() {
     });
 
   // 저장 버튼 클릭 이벤트
-  document
-    .getElementById('createButton')
-    .addEventListener('click', function () {
+  const createButton = document.getElementById('createButton')
+  // 기존의 모든 이벤트 핸들러 제거
+  createButton.replaceWith(createButton.cloneNode(true));
+  const newCreateButton = document.getElementById('createButton');
+  newCreateButton.addEventListener('click', function () {
       // FormData 객체 생성
       const formData = new FormData();
 

--- a/frontend/assets/js/maps/pinDetail.js
+++ b/frontend/assets/js/maps/pinDetail.js
@@ -47,7 +47,7 @@ export function pinDetail() {
 
   /// 백엔드에서 핀 상세보기 정보 가져오기
   function displayPinDetail() {
-    fetch(`${origin}/pin/${PIN_DETAIL.placeId}/`, {
+    fetch(`${origin}/pin/${PIN_DETAIL.place_id}/`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -72,7 +72,7 @@ export function pinDetail() {
   }
 
   function displayPinContents(page) {
-    fetch(`${origin}/pin/${PIN_DETAIL.placeId}/?page=${page}`, {
+    fetch(`${origin}/pin/${PIN_DETAIL.place_id}/?page=${page}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -301,7 +301,7 @@ export function pinDetail() {
       // 선택된 보드 ID 추가
       const selectedBoard = document.getElementById('boardSelection').value;
       formData.append('board_id', selectedBoard);
-
+      
       // 입력된 텍스트 추가
       const textInput = document.getElementById('textInput').value;
       if (textInput) {

--- a/frontend/assets/js/maps/pinDetail.js
+++ b/frontend/assets/js/maps/pinDetail.js
@@ -68,6 +68,16 @@ export function pinDetail() {
         return response.json();
       })
       .then((data) => {
+        // 핀 생성 스텝들 숨기고 초기화하기
+        const pinCreationElement = document.getElementById('pinCreationSteps');
+        pinCreationElement.style.display = 'none';
+        const saveButton = document.getElementById('saveButton');
+        saveButton.innerText = '핀 저장';
+        currentStep = 1;
+        document.getElementById('step1').style.display = 'block';
+        document.getElementById('step2').style.display = 'none';
+        document.getElementById('saveNextButton').style.display = 'block';
+
         pinData = data.results.pin; // 데이터 저장
         createPlaceInfo(data.results);
       })

--- a/frontend/assets/js/maps/pinDetail.js
+++ b/frontend/assets/js/maps/pinDetail.js
@@ -264,17 +264,22 @@ export function pinDetail() {
   let currentStep = 1;
 
   /// "핀 저장" 버튼 클릭 이벤트
-  document.getElementById('saveButton').addEventListener('click', function () {
+  const saveButton = document.getElementById('saveButton');
+  // 기존의 모든 이벤트 핸들러 제거
+  saveButton.replaceWith(saveButton.cloneNode(true));
+  const newSaveButton = document.getElementById('saveButton');
+
+  newSaveButton.addEventListener('click', function () {
     let pinCreationElement = document.getElementById('pinCreationSteps');
     // 만약 핀 생성 스텝들이 이미 보여지고 있다면, 숨기고 함수 종료
     if (pinCreationElement.style.display === 'block') {
       pinCreationElement.style.display = 'none';
-      saveButton.innerText = '핀 저장'; // 텍스트를 원래대로 되돌림
+      newSaveButton.innerText = '핀 저장'; // 텍스트를 원래대로 되돌림
       return;
     }
     // 핀 생성 스텝들 보이기
     pinCreationElement.style.display = 'block';
-    document.getElementById('saveButton').innerText = '취소'; // 텍스트를 '취소'로 변경함
+    newSaveButton.innerText = '취소'; // 텍스트를 '취소'로 변경함
     // 첫 번째 스텝 보이기
     document.getElementById(`step${currentStep}`).style.display = 'block';
   });

--- a/frontend/assets/js/request/content.js
+++ b/frontend/assets/js/request/content.js
@@ -83,7 +83,7 @@ export async function pinSimpleSaveRequest(board, place) {
       category: place.categoryGroupName,
       board_id: board.id,
       title: place.title,
-      place_id: place.placeId,
+      place_id: place.place_id,
       new_address: place.roadAddressName,
       old_address: place.addressName,
       lat_lng: place.lat + ',' + place.lng,

--- a/frontend/assets/js/util/placeInfo.js
+++ b/frontend/assets/js/util/placeInfo.js
@@ -29,7 +29,7 @@ export function createPlaceInfo(data = PIN_DETAIL) {
     updatedAt.style.display = 'none';
     pinCount.style.display = 'none';
     createAddress(data);
-    fetch(`${origin}/pin/no-content/${PIN_DETAIL.placeId}/`, {
+    fetch(`${origin}/pin/no-content/${PIN_DETAIL.place_id}/`, {
       method: 'GET',
       credentials: 'include',
       headers: {


### PR DESCRIPTION
핀 저장 기능에 관한 기능 개선과 추가, 전반적인 에러 수정 작업을 진행하였습니다.
핀이 저장되지 않은 장소에서도 상세보기 페이지를 볼 수 있도록 개선됨에 따라, 이에 맞춰 핀 저장도 가능하도록 설정했습니다.
또한 여러 상황에서 발생할 수 있는 핀 상세보기 모달의 핀 저장 기능과 관련된 에러들을 해결하였습니다.

### 추가 기능
- 사전에 핀이 저장되어 있지 않은 장소의 상세보기 페이지에서도 핀 저장 버튼을 통해 핀을 저장할 수 있도록 설정

### 수정사항
- 핀 저장시 내 보드 선택 드롭다운에 페이지네이션을 고려해 모든 보드들이 추가되도록 수정
- 핀 저장 완료시 뜨는 창에 표시되던 보드 pk값을 보드 이름으로 변경하고 저장한 핀 이름을 추가
<img width="500px" alt="image" src="https://github.com/inslog94/FavSpot/assets/131739343/c80f5331-f58a-43ac-afd5-f66ca3dfa206">

- 핀 상세보기 모달의 핀 저장 버튼 클릭 이벤트가 두 번에 한번만 작동되던 에러 해결
- 핀 상세보기 모달을 여러 번 들어갔다 나간 다음 핀을 저장하면 그 횟수만큼 중복해서 저장되는 에러 해결
- 핀 상세보기 모달에서 핀 저장 버튼을 눌러 핀 저장 폼을 열어놓은 채로 나갔다가 다시 들어올 경우에 저장 폼이 닫힌 초기 상태로 되돌아가도록 수정

close #131 