### PR TITLE
핀 상세보기 모달 예외처리 및 UI 일부 수정

### DIFF
--- a/frontend/assets/html/board_detail.html
+++ b/frontend/assets/html/board_detail.html
@@ -650,6 +650,7 @@
                               <button
                                 id="saveButton"
                                 class="button button-border mt-2 mb-3 form-button"
+                                style="display: none"
                               >
                                 핀 저장
                               </button>
@@ -742,13 +743,13 @@
                       </div>
                     </div>
                     <button
-                      type="button"
-                      class="close btn btn-lg p-0"
-                      data-bs-dismiss="modal"
-                      aria-label="Close"
-                    >
-                      <span aria-hidden="true">&times;</span>
-                    </button>
+                    type="button"
+                    class="close btn btn-lg p-0"
+                    data-bs-dismiss="modal"
+                    aria-label="Close"
+                  >
+                    <span aria-hidden="true">&times;</span>
+                  </button>
                   </div>
                   <div
                     class="static-container d-flex justify-content-center align-items-center"

--- a/frontend/assets/html/board_detail.html
+++ b/frontend/assets/html/board_detail.html
@@ -633,7 +633,7 @@
             >
               <div class="modal-dialog modal-lg mt-0">
                 <div class="modal-content">
-                  <div class="modal-header align-items-start">
+                  <div class="modal-header align-items-start" style="justify-content: center">
                     <div class="modal-title" id="exampleModalLongTitle">
                       <div class="section-title mb-10">
                         <div class="blog-entry mb-10">
@@ -742,14 +742,6 @@
                         </div>
                       </div>
                     </div>
-                    <button
-                    type="button"
-                    class="close btn btn-lg p-0"
-                    data-bs-dismiss="modal"
-                    aria-label="Close"
-                  >
-                    <span aria-hidden="true">&times;</span>
-                  </button>
                   </div>
                   <div
                     class="static-container d-flex justify-content-center align-items-center"

--- a/frontend/assets/js/maps/pinDetail.js
+++ b/frontend/assets/js/maps/pinDetail.js
@@ -43,6 +43,8 @@ export function pinDetail() {
             boardData[board.id] = { title: board.title };
 
             boardSelectionElement.appendChild(optionElement);
+
+            document.getElementById('saveButton').style.display = 'block';
           });
         }
       })
@@ -362,7 +364,7 @@ export function pinDetail() {
           // 성공 메시지 출력
           alert(`'${pinData.title}' 핀을 '${boardData[selectedBoard].title}' 보드에 담았습니다.`);
           // 페이지 새로 고침
-          // window.location.reload();
+          displayPinDetail();
           displayPinContents(1);
         })
         .catch((error) => {

--- a/frontend/assets/js/util/pinDetailModal.js
+++ b/frontend/assets/js/util/pinDetailModal.js
@@ -10,7 +10,7 @@ export function createPinDetail() {
   modal.innerHTML = `
 <div class="modal-dialog modal-lg mt-0">
   <div class="modal-content">
-    <div class="modal-header align-items-start">
+    <div class="modal-header align-items-start" style="justify-content: center">
       <div class="modal-title" id="exampleModalLongTitle">
         <div class="section-title mb-10">
           <div class="blog-entry mb-10">
@@ -109,14 +109,6 @@ export function createPinDetail() {
           </div>
         </div>
       </div>
-      <button
-      type="button"
-      class="close btn btn-lg p-0"
-      data-bs-dismiss="modal"
-      aria-label="Close"
-    >
-      <span aria-hidden="true">&times;</span>
-    </button>
     </div>
     <div
       class="static-container d-flex justify-content-center align-items-center"

--- a/frontend/assets/js/util/pinDetailModal.js
+++ b/frontend/assets/js/util/pinDetailModal.js
@@ -43,6 +43,7 @@ export function createPinDetail() {
                 <button
                   id="saveButton"
                   class="button button-border mt-2 mb-3 form-button"
+                  style="display: none"
                 >
                   핀 저장
                 </button>
@@ -109,13 +110,13 @@ export function createPinDetail() {
         </div>
       </div>
       <button
-        type="button"
-        class="close btn btn-lg p-0"
-        data-bs-dismiss="modal"
-        aria-label="Close"
-      >
-        <span aria-hidden="true">&times;</span>
-      </button>
+      type="button"
+      class="close btn btn-lg p-0"
+      data-bs-dismiss="modal"
+      aria-label="Close"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
     </div>
     <div
       class="static-container d-flex justify-content-center align-items-center"


### PR DESCRIPTION
핀 상세보기 모달에서 로그인하지 않았거나 보드가 하나도 없는 유저는 핀 저장 버튼이 나타나지 않도록 개선했습니다. 그리고 모달 우측 상단에 위치한 모달 닫기 버튼이 불필요하다고 생각되어 제거한 뒤 핀 상세정보를 보여주는 컨테이너를 중앙 정렬하도록 UI를 수정했습니다.

### 수정사항
- 로그인하지 않은 경우와 로그인한 유저의 보드가 하나도 없을 때는 핀 상세보기 모달에서 핀 저장을 할 수 없도록 핀 저장 버튼이 보이지 않도록 처리
- 핀 상세보기 모달에서 우측 상단에 위치한 모달 닫기 버튼이 불필요하다고 판단하여(모달 바깥을 누르거나 모달 하단의 close 버튼을 누르면 닫힘) 제거한 뒤, 닫기 버튼 때문에 왼쪽으로 치우쳐 있던 핀 상세정보 표시 컨테이너를 중앙으로 옮김