### PR TITLE
장소 검색 시 특정 장소들의 썸네일 이미지가 디폴트 이미지로 설정되는 문제 해결

### DIFF
--- a/frontend/assets/js/maps/pin.js
+++ b/frontend/assets/js/maps/pin.js
@@ -332,7 +332,12 @@ export async function displayPinOverlay(markerInfo) {
   })
     .then((response) => response.json())
     .then((pinData) => {
-      if (!pinData.thumbnail_img.includes('http://t1.daumcdn.net/')) {
+      if (
+        !(
+          pinData.thumbnail_img.includes('daumcdn') ||
+          pinData.thumbnail_img.includes('kakaocdn')
+        )
+      ) {
         img.src =
           'https://favspot-fin.s3.amazonaws.com/images/default/main_logo.png';
       } else if (pinData.thumbnail_img) {

--- a/frontend/assets/js/util/getPlaceInfo.js
+++ b/frontend/assets/js/util/getPlaceInfo.js
@@ -33,7 +33,16 @@ export function createMenu(data) {
 export function createThumbnailImg(dataPin) {
   const subscribeIconElement = document.querySelector('.subscribe-icon');
   // thumbnail_img를 보여주기
-  if (dataPin.thumbnail_img) {
+  if (
+    !(
+      dataPin.thumbnail_img.includes('daumcdn') ||
+      dataPin.thumbnail_img.includes('kakaocdn')
+    )
+  ) {
+    subscribeIconElement.src =
+      'https://favspot-fin.s3.amazonaws.com/images/default/main_logo.png';
+    subscribeIconElement.style = 'width: 100%;';
+  } else if (dataPin.thumbnail_img) {
     subscribeIconElement.src = `${dataPin.thumbnail_img}`; // thumbnail_img 사진과 연결
   } else {
     subscribeIconElement.src =


### PR DESCRIPTION
## 수정사항
#### 썸네일 이미지의 예외 처리를 하는 과정에서 경로 누락이 원인
* 정상적인 이미지 경로들의 공통점을 찾아내 예외 처리(pin.js)
* 비슷한 이유로 핀 상세보기 페이지에서 특정 장소들의 이미지가 나타나지 않던 문제 해결(getPlaceInfo.js)

close #153 