### PR TITLE
지도 우측 상단 옵션값(지도/스카이뷰, 확대/축소)이 잘려 보이는 문제 해결

### DIFF
--- a/frontend/assets/js/maps/event.js
+++ b/frontend/assets/js/maps/event.js
@@ -85,10 +85,18 @@ export function mapSetup() {
   MAP_OPTIONS.level = INIT_MAP_LEVEL;
 
   // 지도 타입, 확대/축소
-  let mapTypeControl = new kakao.maps.MapTypeControl();
-  let zoomControl = new kakao.maps.ZoomControl();
-  MAP.addControl(mapTypeControl, kakao.maps.ControlPosition.TOPRIGHT);
-  MAP.addControl(zoomControl, kakao.maps.ControlPosition.RIGHT);
+  const currentPathname = window.location.pathname;
+  if (
+    !(
+      currentPathname == '/frontend/index.html' ||
+      currentPathname == '/frontend/'
+    )
+  ) {
+    let mapTypeControl = new kakao.maps.MapTypeControl();
+    let zoomControl = new kakao.maps.ZoomControl();
+    MAP.addControl(mapTypeControl, kakao.maps.ControlPosition.TOPRIGHT);
+    MAP.addControl(zoomControl, kakao.maps.ControlPosition.RIGHT);
+  }
 
   kakao.maps.event.addListener(MAP, 'click', (mouseEvent) => {
     removeAllOverlay();


### PR DESCRIPTION
## 수정사항
* Index Page의 경우 옵션값이 나타나지 않도록 설정(Index Page에서만 문제 발생)

## 참고사항
* 보드 상세보기 페이지에서는 유용하게 사용될 수 있을 것 같다는 판단으로 유지

close #155 