### PR TITLE
콘솔창에 지속적으로 이벤트 리스너 에러 메시지가 발생하는 문제 해결

### DIFF
--- a/frontend/assets/js/maps/event.js
+++ b/frontend/assets/js/maps/event.js
@@ -434,9 +434,15 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelector('.drop3')
   ];
 
-  // 각 드롭다운 메뉴 항목에 대해 이벤트 리스너 추가
-  dropOptions.forEach((dropOption, index) => {
-    sortMouseEvent(dropOption);
-    sortClickEvent(dropOption, index, "http://127.0.0.1:8000/board");
-  });
+  const currentPathname = window.location.pathname;
+  if (
+    currentPathname == '/frontend/assets/html/index.html#' ||
+    currentPathname == '/frontend/assets/html/index.html'
+  ) {
+    // 각 드롭다운 메뉴 항목에 대해 이벤트 리스너 추가
+    dropOptions.forEach((dropOption, index) => {
+      sortMouseEvent(dropOption);
+      sortClickEvent(dropOption, index, 'http://127.0.0.1:8000/board');
+    });
+  }
 });


### PR DESCRIPTION
## 수정사항
#### 정렬 기능 이벤트 리스너가 Index를 제외한 나머지 페이지에서도 실행되던 것이 원인
* 정렬 기능을 위한 이벤트리스너가 Index Page에서만 실행되도록 수정

close #164 