### PR TITLE
핀 코멘트 관련 최적화, 핀 상세보기 모달 및 보드 상세보기 페이지 UI수정

### DIFF
--- a/everyplace/user/serializers.py
+++ b/everyplace/user/serializers.py
@@ -11,11 +11,10 @@ class UserSerializer(serializers.ModelSerializer):
     following = serializers.SerializerMethodField()
     following_list = serializers.SerializerMethodField()
     tags = serializers.SerializerMethodField()
-    pin_contents = serializers.SerializerMethodField()
     
     class Meta:
         model = get_user_model()
-        fields = ('id', 'email', 'password', 'nickname', 'profile_img', 'pin_contents', 'followers', 'following', 'following_list', 'tags')
+        fields = ('id', 'email', 'password', 'nickname', 'profile_img', 'followers', 'following', 'following_list', 'tags')
         extra_kwargs = {'password': {'write_only': True}}
 
     def get_followers(self, obj):
@@ -34,11 +33,6 @@ class UserSerializer(serializers.ModelSerializer):
         board_tags = set(BoardTag.objects.filter(board__user_id=obj, board__is_deleted=False))
         tag_contents = [tag.content for tag in board_tags if tag.content]
         return tag_contents
-    
-    def get_pin_contents(self, obj):
-        pin_contents = PinContent.objects.filter(user_id=obj.id, is_deleted=False).order_by(('-updated_at'))
-        serializer = PinContentSerializer(pin_contents, many=True)
-        return serializer.data
 
 
 class FollowingSerializer(serializers.ModelSerializer):

--- a/frontend/assets/js/maps/boardDetail.js
+++ b/frontend/assets/js/maps/boardDetail.js
@@ -186,7 +186,7 @@ export async function boardDetail(data) {
       imgElement.src = pin.thumbnail_img;
       } else {
         imgElement.src =
-          'https://favspot-fin.s3.amazonaws.com/images/default/default_place.png';
+          'https://favspot-fin.s3.amazonaws.com/images/default/main_logo.png';
       }
       imgElement.classList.add('pin-thumbnail-img');
 

--- a/frontend/assets/js/maps/pinDetail.js
+++ b/frontend/assets/js/maps/pinDetail.js
@@ -144,7 +144,12 @@ export function pinDetail() {
 
           // 핀 콘텐츠 텍스트 p 요소 생성 및 추가
           const pinContentP = document.createElement('p');
-          pinContentP.textContent = pinContent.text;
+          pinContentP.className = 'mt-20';
+          if (pinContent.text) {
+            pinContentP.textContent = pinContent.text;
+          } else {
+            pinContentP.textContent = "입력된 코멘트가 없습니다";
+          }
 
           infoContainer.appendChild(pinContentP);
 


### PR DESCRIPTION
핀 코멘트 목록 뷰를 분리해서 생성함에 따라 UserSerializer에서 응답받던 핀 코멘트 목록을 제거했습니다. 그 외에 핀 코멘트와 보드 상세보기 관련 UI를 수정했습니다.

### 수정사항
- UserSerializer의 응답 중 핀 코멘트 목록 제거(응답 속도 증가) 
- 핀 코멘트 내용이 없을시 핀 상세정보 모달에서 디폴트 문구 추가 및 코멘트 윗 여백 추가
- 핀 썸네일 이미지가 없을 시 보드 상세보기 페이지에서 보이는 디폴트 이미지를 로고 이미지로 변경