### PR TITLE
배포 전 테스트 중 발견한 이미지 관련 오류 수정

### DIFF
--- a/frontend/assets/js/boardDetail.js
+++ b/frontend/assets/js/boardDetail.js
@@ -251,7 +251,7 @@ export async function boardDetail(data) {
 
   // 댓글 작성란 유저 프로필 이미지 설정
   const replyprofileImg = document.querySelector('.img-profile');
-  if (data.request_user.profileImg) {
+  if (data.request_user.profileImg && data.request_user.profileImg != "https://favspot-fin.s3.amazonaws.com/") {
     replyprofileImg.src = data.request_user.profileImg;
   }
 

--- a/frontend/assets/js/util/header.js
+++ b/frontend/assets/js/util/header.js
@@ -345,7 +345,7 @@ document.addEventListener('DOMContentLoaded', function () {
           const nickname = (document.querySelector('#nickname').value =
             data['results']['User']['nickname']);
           const imagePreview = document.getElementById('imagePreview');
-          if (profileImg) {
+          if (requestUserProfileImg) {
             imagePreview.src = requestUserProfileImg;
           }
         } else if (

--- a/frontend/assets/js/util/pinDetailModal.js
+++ b/frontend/assets/js/util/pinDetailModal.js
@@ -14,6 +14,13 @@ export function createPinDetail() {
       <div class="modal-title" id="exampleModalLongTitle">
         <div class="section-title mb-10">
           <div class="blog-entry mb-10">
+            <div class="entry-image clearfix">
+            <img
+            class="img-fluid subscribe-icon"
+            src=""
+            alt="thumbnail img"
+          />
+            </div>
             <div class="blog-detail">
               <div class="title-wrap">
                 <h1 id="myModalLabel">Pin title</h1>
@@ -111,6 +118,9 @@ export function createPinDetail() {
     <!-- 핀 콘텐츠가 만들어질 컨테이너 -->
     <div id="pinContentsContainer" class="modal-body">
       <div class="port-post clearfix">
+        <div class="port-post-photo">
+        <img src="" alt="pin-comment-photo" />
+        </div>
         <div class="port-post-info">
           <h3 class="theme-color">Kevin Martin</h3>
           <button type="button" class="close btn btn-lg p-0">


### PR DESCRIPTION
배포를 위한 코드 통합과정에서 누락된 핀 상세보기 모달의 썸네일 이미지 표시 부분을 복구하였습니다. 또한 프로필 사진이 없는 유저의 경우 디폴트 유저 이미지가 표시되어야 하는 부분에서 이미지가 제대로 표시되지 않는 페이지를 수정하였습니다.

### 수정사항
- 핀 상세보기 모달의의 썸네일 이미지 표시 코드 복구
- 프로필 사진이 없는 유저의 경우 디폴트 이미지가 표시되어야 하지만 표시되지 않는 부분을 제대로 표시되도록 수정
  - 보드 상세보기 페이지 댓글 작성란의 유저 프로필 사진
  - 프로필 수정 페이지의 프로필 사진 미리보기