### PR TITLE
핀 간편저장 관련 에러 해결 및 개선

### DIFF
--- a/src/backend/board/views.py
+++ b/src/backend/board/views.py
@@ -552,7 +552,7 @@ class BoardSearchView(APIView):
 
             if search_field == 'all':
                 queryset = queryset.annotate(pin_count=Count('pin')).filter(pin_count__gt=0).filter(
-            Q(title__icontains=search_term) | Q(tags__content__icontains=search_term)).distinct()
+            Q(title__icontains=search_term) | Q(tags__content__icontains=search_term) | Q(pin__title__icontains=search_term)).distinct()
                 
             # # 보드 제목으로 검색
             # elif search_field == 'title':
@@ -572,8 +572,8 @@ class BoardSearchView(APIView):
 
             # 제목 또는 태그 내용으로 검색
             if search_field == 'all':
-                user_boards_filtered = user_boards.annotate(pin_count=Count('pin')).filter(pin_count__gt=0).filter(Q(title__icontains=search_term) | Q(tags__content__icontains=search_term)).distinct()
-                public_boards_filtered_except_user_ones = public_boards_except_user_ones.annotate(pin_count=Count('pin')).filter(pin_count__gt=0).filter(Q(title__icontains=search_term) | Q(tags__content__icontains=search_term)).distinct()
+                user_boards_filtered = user_boards.annotate(pin_count=Count('pin')).filter(pin_count__gt=0).filter(Q(title__icontains=search_term) | Q(tags__content__icontains=search_term) | Q(pin__title__icontains=search_term)).distinct()
+                public_boards_filtered_except_user_ones = public_boards_except_user_ones.annotate(pin_count=Count('pin')).filter(pin_count__gt=0).filter(Q(title__icontains=search_term) | Q(tags__content__icontains=search_term) | Q(pin__title__icontains=search_term)).distinct()
 
             # 태그 내용으로 검색
             elif search_field == 'tag':

--- a/src/backend/pin/urls.py
+++ b/src/backend/pin/urls.py
@@ -4,8 +4,8 @@ from . import views
 app_name = 'pin'
 
 urlpatterns = [
-    # 핀 생성
-    path('', views.PinCreateView.as_view(), name='pin-create'),
+    # 핀 생성, 제거
+    path('', views.PinView.as_view(), name='pin'),
     # 핀 컨텐츠 수정, 삭제
     path('content/<int:pk>/',
          views.PinContentView.as_view(), name='pin-content'),

--- a/src/backend/pin/views.py
+++ b/src/backend/pin/views.py
@@ -49,6 +49,8 @@ def get_thumbnail_img(place_id):
     # "list" 하위 첫번째 사진의 url 값 가져오기
     try:
         thumbnail_img = data["photoViewer"]["list"][0]['url']
+        if len(thumbnail_img) > 150:
+            thumbnail_img = ''
     except KeyError:
         thumbnail_img = ''
 

--- a/src/backend/pin/views.py
+++ b/src/backend/pin/views.py
@@ -131,7 +131,7 @@ class PinDetailView(APIView):
         })
 
 
-class PinCreateView(APIView):
+class PinView(APIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     @extend_schema(
@@ -241,6 +241,17 @@ class PinCreateView(APIView):
             'pin_errors': pin_serializer.errors,
             'pin_content_errors': {}
         }, status=status.HTTP_400_BAD_REQUEST)
+
+    # 핀과 연결된 특정 보드 제거
+    def delete(self, request):
+        board_id = request.data.get('board_id')
+        place_id = request.data.get('place_id')
+        pin = Pin.objects.get(place_id=place_id)
+        pin.board_id.remove(board_id)
+        pin.save()
+        serializer = PinSerializer(pin)
+
+        return Response(serializer.data, status=status.HTTP_204_NO_CONTENT)
 
 
 class PinContentView(APIView):

--- a/src/frontend/assets/html/board_detail.html
+++ b/src/frontend/assets/html/board_detail.html
@@ -304,6 +304,7 @@
                               class="img-fluid subscribe-icon"
                               src=""
                               alt=""
+                              style="object-fit: cover;"
                             />
                           </div>
                           <div class="blog-detail">

--- a/src/frontend/assets/js/content.js
+++ b/src/frontend/assets/js/content.js
@@ -62,7 +62,7 @@ export async function getBoardRequest(keyword) {
     },
   });
 
-  if (!response.ok) {
+if (!response.ok) {
     location.reload();
   }
   const resJson = await response.json();
@@ -138,18 +138,22 @@ export async function pinSimpleSaveRequest(board, place) {
   return response;
 }
 
-export async function pinDeleteRequest(id) {
-  let url = origin + '/pin/content/' + id + '/';
+export async function pinDeleteRequest(board, place_id) {
+  let url = origin + '/pin/';
 
   const response = await fetch(url, {
     method: 'DELETE',
+    body: JSON.stringify({
+      board_id: typeof board === 'number' ? board : board.id,
+      place_id: place_id
+    }),
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },
   }).catch((error) => {
-    alert(error);
+    console.error(error);
   });
 
   return response;

--- a/src/frontend/assets/js/pin.js
+++ b/src/frontend/assets/js/pin.js
@@ -1,6 +1,7 @@
 import {
   getPinContentsRequest,
   pinSimpleSaveRequest,
+  pinDeleteRequest,
 } from '/assets/js/content.js';
 import { setMyBoard } from './board.js';
 import {
@@ -536,7 +537,7 @@ function pinSimpleSaveEvent(element, board, place, pinsaved) {
       }
     } else {
       if (confirm('핀을 삭제하시겠습니까?')) {
-        // let response = await pinDeleteRequest(place.id);
+        let response = await pinDeleteRequest(board, place.place_id);
 
         element.innerText = '생성';
         element.classList.remove('pin_saved_btn');

--- a/src/frontend/assets/js/pin.js
+++ b/src/frontend/assets/js/pin.js
@@ -3,7 +3,7 @@ import {
   pinSimpleSaveRequest,
   pinDeleteRequest,
 } from '/assets/js/content.js';
-import { setMyBoard } from './board.js';
+import { setMyBoard, displayRelatedBoards } from './board.js';
 import {
   MAP,
   $searchResultList,
@@ -22,6 +22,7 @@ import {
   $staticContainer,
   $boardAddModal,
   $boardAddModalContent,
+  $keyword,
 } from './data.js';
 import { displayMarkerDetailInfo } from './event.js';
 import { removeAllMarker, displayMarkers, move } from './map.js';
@@ -33,7 +34,7 @@ export async function pinSimpleSave(board, place) {
   if (response.status >= 400 && response.status <= 500) {
     return false;
   }
-
+  displayRelatedBoards($keyword.value);
   return true;
 }
 
@@ -543,6 +544,7 @@ function pinSimpleSaveEvent(element, board, place, pinsaved) {
         element.classList.remove('pin_saved_btn');
         element.classList.add('pin_save_btn');
         pinsaved = false;
+        displayRelatedBoards($keyword.value);
       }
     }
   });


### PR DESCRIPTION
핀 간편삭제 기능이 아직 제대로 구현되지 않아 새롭게 간편 삭제 view를 생성하여 프론트 페이지와 연결시켰습니다. 그리고 메인페이지의 검색 기능 사용시 키워드가 보드에 들어있는 핀의 제목에 포함된 경우에 그 보드도 검색 결과에 포함되도록 하고, 간편 핀 저장 및 삭제 시 그 변경사항이 즉석에서 반영되어 오른쪽 보드 목록에 표시되도록 개선하였습니다. 마지막으로 핀 썸네일 이미지를 크롤링할 때 경로 길이가 150자 이상일 때(핀 모델에서 설정된 썸네일 이미지 필드 최대 길이) 핀이 저장되지 않는 상황을 예외 처리하고, 보드 상세보기 페이지에서 띄우는 핀 상세보기 모달의 썸네일 이미지 비율 css를 수정했습니다.

### 수정사항
- 보드 검색 시 검색한 키워드가 보드에 담겨있는 핀의 제목에 포함된 경우에도 검색 결과에 포함되도록 개선
- 핀 간편 저장 및 삭제 시 변경사항을 검색된 보드 목록에 즉시 반영
- 크롤링한 핀 썸네일 이미지의 경로가 150자(핀 모델에서 설정한 썸네일 이미지 필드의 제한 글자수) 이상일 때 핀이 저장되지 않는 문제 예외 처리
- 보드 상세보기 페이지에서 띄우는 핀 상세보기 모달의 썸네일 이미지 비율 조절

### 추가 기능
- 핀 간편 삭제 기능 구현 및 프론트 연결

close #179 