### PR TITLE
보드 검색시 검색 키워드 뿐만 아니라 검색 결과 장소명 목록으로도 검색되도록 개선

### DIFF
--- a/src/frontend/assets/js/pin.js
+++ b/src/frontend/assets/js/pin.js
@@ -34,7 +34,7 @@ export async function pinSimpleSave(board, place) {
   if (response.status >= 400 && response.status <= 500) {
     return false;
   }
-  displayRelatedBoards($keyword.value);
+  displayRelatedBoards(MARKERS.map(marker => marker.title).concat($keyword.value));
   return true;
 }
 
@@ -343,7 +343,7 @@ export async function displayPinOverlay(markerInfo) {
         img.src =
           'https://favspot-fin.s3.amazonaws.com/images/default/main_logo.png';
       } else if (pinData.thumbnail_img) {
-        img.src = pinData.thumbnail_img;
+                img.src = pinData.thumbnail_img;
       } else {
         img.src =
           'https://favspot-fin.s3.amazonaws.com/images/default/main_logo.png';
@@ -397,7 +397,7 @@ export async function displayPinOverlay(markerInfo) {
         .then((response) => response.json())
         .then((data) => {
           let boards = data.results.Boards;
-          if (!recursion) {
+if (!recursion) {
             MY_BOARDS.length = 0;
           }
           boards.forEach((board) => {
@@ -543,7 +543,7 @@ function pinSimpleSaveEvent(element, board, place, pinsaved) {
         element.classList.remove('pin_saved_btn');
         element.classList.add('pin_save_btn');
         pinsaved = false;
-        displayRelatedBoards($keyword.value);
+        displayRelatedBoards(MARKERS.map(marker => marker.title).concat($keyword.value));
       }
     }
   });

--- a/src/frontend/assets/js/search.js
+++ b/src/frontend/assets/js/search.js
@@ -5,6 +5,7 @@ import {
   CURRENT_POSITION,
   PIN_SAVE_OVERLAY,
   MARKER_OVERLAY,
+  MARKERS,
 } from './data.js';
 import { removeAllOverlay } from './event.js';
 import { displaySearchPlace, displayPagination } from './pin.js';
@@ -53,7 +54,7 @@ function searchPlaceAsKeywordCB(data, status, pagination) {
     displayPagination(pagination);
 
     // 검색 결과 관련된 보드 표시
-    displayRelatedBoards($keyword.value);
+    displayRelatedBoards(MARKERS.map(marker => marker.title).concat($keyword.value));
   } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
     alert('검색 결과가 존재하지 않습니다.');
     return;


### PR DESCRIPTION
메인페이지의 검색 기능 사용시 검색한 키워드 뿐만이 아니라 검색 결과에 포함된 장소명 중 하나라도 포함된 핀이 들어있는 보드 또한 오른쪽 보드 목록에 표시되도록 개선하였습니다. [앞선 개선사항](https://github.com/inslog94/FavSpot/pull/180)과 마찬가지로 간편 핀 저장 및 삭제 시에도 변경사항이 즉석에서 반영됩니다.

### 수정사항
- 보드 검색 시 검색한 키워드 뿐만 아니라 검색 결과에 포함된 장소명 목록으로도 검색되도록 개선

close #184 